### PR TITLE
Add geohazardwatch app + Flux image automation

### DIFF
--- a/apps/production/geohazardwatch/README.md
+++ b/apps/production/geohazardwatch/README.md
@@ -11,15 +11,37 @@ Built on the [`ngdpbase`](https://github.com/jwilleke/ngdpbase) wiki engine with
 - **Public path**: Cloudflare Tunnel → cluster Service direct (bypasses Traefik). Wired up separately — see geohazardwatch issues #14-18.
 - **Internal path**: Traefik IngressRoute on `geohazardwatch.nerdsbythehour.com` with a cert-manager Let's Encrypt cert. Used to verify the pod independently of the tunnel.
 
-## Auto-update flow
+## Auto-update flow (requires one-time bootstrap step)
 
-1. New `ngdpbase` image published → Renovate (in the `geohazardwatch` repo) opens a PR bumping the base image; minor/patch auto-merge.
-2. Merge to `master` triggers `publish-image.yml` → new `ghcr.io/jwilleke/geohazardwatch:X.Y.Z`.
-3. Flux `ImageRepository` + `ImagePolicy` (this app) detect the new tag (semver range `>=1.0.0 <2.0.0`).
-4. `ImageUpdateAutomation` rewrites the `image:` line in `deployment.yaml` and `cronjob-import.yaml` and commits to `master`.
-5. Flux reconciles → rolling deploy.
+The production cluster's Flux currently runs with only the four core controllers (`source`, `kustomize`, `helm`, `notification`). Image automation is **not yet enabled** — `image-reflector-controller` and `image-automation-controller` need to be added before `image-policy.yaml` can be activated.
+
+### One-time bootstrap
+
+Re-run `flux bootstrap` with the extra components, e.g.:
+
+```bash
+flux bootstrap github \
+  --owner=jwilleke \
+  --repository=mj-infra-flux \
+  --branch=master \
+  --path=clusters/production \
+  --components-extra=image-reflector-controller,image-automation-controller
+```
+
+(Or hand-edit `clusters/production/flux-system/gotk-components.yaml` and add the two controllers + their CRDs.)
+
+### Once bootstrapped
+
+1. Add `- image-policy.yaml` to `kustomization.yaml` here.
+2. New `ngdpbase` image published → Renovate (in the `geohazardwatch` repo) opens a PR bumping the base image; minor/patch auto-merge.
+3. Merge to `master` triggers `publish-image.yml` → new `ghcr.io/jwilleke/geohazardwatch:X.Y.Z`.
+4. Flux `ImageRepository` + `ImagePolicy` detect the new tag (semver range `>=1.0.0 <2.0.0`).
+5. `ImageUpdateAutomation` rewrites the `image:` line in `deployment.yaml` and `cronjob-import.yaml` and commits to `master`.
+6. Flux reconciles → rolling deploy.
 
 Major bumps (e.g., `1.x.x` → `2.0.0`) are NOT auto-deployed — the `ImagePolicy` range must be widened by hand.
+
+Until image automation is bootstrapped, image bumps are entirely manual: edit the `image:` lines in `deployment.yaml` and `cronjob-import.yaml`, commit, and let Flux roll out.
 
 ## Data refresh
 

--- a/apps/production/geohazardwatch/README.md
+++ b/apps/production/geohazardwatch/README.md
@@ -1,0 +1,65 @@
+# geohazardwatch
+
+Public site at `https://geohazardwatch.com` (via Cloudflare Tunnel — see follow-up). Internal LAN at `https://geohazardwatch.nerdsbythehour.com` (Traefik + cert-manager).
+
+Built on the [`ngdpbase`](https://github.com/jwilleke/ngdpbase) wiki engine with the [`ve-geology`](https://github.com/jwilleke/geohazardwatch) addon (GVP volcanoes, USGS earthquakes, USGS HANS alerts).
+
+## Architecture
+
+- **Image**: `ghcr.io/jwilleke/geohazardwatch:X.Y.Z` — built and published from the `jwilleke/geohazardwatch` repo. Layered on `ghcr.io/jwilleke/ngdpbase`.
+- **Data volume**: `hostPath /mnt/tank/jims/data/systems/geohazardwatch` mounted at `/app/data`. Holds wiki pages, users, sessions, search index, and the imported geology data.
+- **Public path**: Cloudflare Tunnel → cluster Service direct (bypasses Traefik). Wired up separately — see geohazardwatch issues #14-18.
+- **Internal path**: Traefik IngressRoute on `geohazardwatch.nerdsbythehour.com` with a cert-manager Let's Encrypt cert. Used to verify the pod independently of the tunnel.
+
+## Auto-update flow
+
+1. New `ngdpbase` image published → Renovate (in the `geohazardwatch` repo) opens a PR bumping the base image; minor/patch auto-merge.
+2. Merge to `master` triggers `publish-image.yml` → new `ghcr.io/jwilleke/geohazardwatch:X.Y.Z`.
+3. Flux `ImageRepository` + `ImagePolicy` (this app) detect the new tag (semver range `>=1.0.0 <2.0.0`).
+4. `ImageUpdateAutomation` rewrites the `image:` line in `deployment.yaml` and `cronjob-import.yaml` and commits to `master`.
+5. Flux reconciles → rolling deploy.
+
+Major bumps (e.g., `1.x.x` → `2.0.0`) are NOT auto-deployed — the `ImagePolicy` range must be widened by hand.
+
+## Data refresh
+
+A nightly `CronJob` (`geohazardwatch-data-refresh`) runs the addon's import scripts at 08:00 UTC and writes JSON snapshots into `/app/data/ve-geology/` on the persistent volume. Re-run on demand:
+
+```bash
+kubectl -n geohazardwatch create job --from=cronjob/geohazardwatch-data-refresh manual-refresh-$(date +%s)
+```
+
+## Secrets
+
+A session secret can be created out-of-band (not yet required — image runs in headless install mode with default admin/admin123, change via web UI on first login):
+
+```bash
+kubectl -n geohazardwatch create secret generic geohazardwatch-secrets \
+  --from-literal=session-secret=$(openssl rand -base64 32)
+```
+
+## First deploy notes
+
+- The hostPath `/mnt/tank/jims/data/systems/geohazardwatch` is auto-created (`DirectoryOrCreate`). Confirm permissions allow uid/gid 1000 to write.
+- Default credentials `admin` / `admin123` — change immediately after first access.
+- Run an initial data import once before relying on the site:
+  ```bash
+  kubectl -n geohazardwatch create job --from=cronjob/geohazardwatch-data-refresh initial-import
+  ```
+
+## Troubleshooting
+
+```bash
+kubectl -n geohazardwatch get pods -o wide
+kubectl -n geohazardwatch logs -l app=geohazardwatch --tail=200
+kubectl -n geohazardwatch describe pod -l app=geohazardwatch
+kubectl -n geohazardwatch get certificate
+```
+
+Image automation status:
+
+```bash
+flux -n flux-system get image repository geohazardwatch
+flux -n flux-system get image policy geohazardwatch
+flux -n flux-system get image update geohazardwatch
+```

--- a/apps/production/geohazardwatch/certificate.yaml
+++ b/apps/production/geohazardwatch/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: geohazardwatch-cert
+  namespace: geohazardwatch
+spec:
+  secretName: geohazardwatch-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - geohazardwatch.nerdsbythehour.com

--- a/apps/production/geohazardwatch/configmap.yaml
+++ b/apps/production/geohazardwatch/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: geohazardwatch-config
+  namespace: geohazardwatch
+data:
+  app-custom-config.json: |
+    {
+      "ngdpbase.server.host": "0.0.0.0",
+      "ngdpbase.server.port": 3000,
+      "ngdpbase.application.base-url": "https://geohazardwatch.com",
+      "ngdpbase.application-name": "GeoHazardWatch",
+      "ngdpbase.session.secure": true,
+      "ngdpbase.session.sameSite": "lax",
+      "ngdpbase.managers.addons-manager.addons-path": "/opt/geohazardwatch/addons",
+      "ngdpbase.addons.ve-geology.enabled": true,
+      "ngdpbase.addons.ve-geology.dataPath": "/app/data/ve-geology"
+    }

--- a/apps/production/geohazardwatch/cronjob-import.yaml
+++ b/apps/production/geohazardwatch/cronjob-import.yaml
@@ -19,7 +19,7 @@ spec:
             fsGroup: 1000
           containers:
             - name: import
-              image: ghcr.io/jwilleke/geohazardwatch:1.0.1 # {"$imagepolicy": "flux-system:geohazardwatch"}
+              image: ghcr.io/jwilleke/geohazardwatch:1.1.2 # {"$imagepolicy": "flux-system:geohazardwatch"}
               imagePullPolicy: IfNotPresent
               workingDir: /opt/geohazardwatch
               command:

--- a/apps/production/geohazardwatch/cronjob-import.yaml
+++ b/apps/production/geohazardwatch/cronjob-import.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: geohazardwatch-data-refresh
+  namespace: geohazardwatch
+spec:
+  # 04:00 America/New_York (08:00 UTC) — low-traffic
+  schedule: "0 8 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            fsGroup: 1000
+          containers:
+            - name: import
+              image: ghcr.io/jwilleke/geohazardwatch:1.0.1 # {"$imagepolicy": "flux-system:geohazardwatch"}
+              imagePullPolicy: IfNotPresent
+              workingDir: /opt/geohazardwatch
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  DATA_DIR=/app/data/ve-geology
+                  mkdir -p "$DATA_DIR"
+                  echo "Importing GVP volcanoes + eruptions + global activity..."
+                  node addons/ve-geology/import/import-volcanoes.js \
+                    --eruptions --activity --data-dir "$DATA_DIR"
+                  echo "Importing USGS earthquakes..."
+                  node addons/ve-geology/import/import-earthquakes.js \
+                    --data-dir "$DATA_DIR"
+                  echo "Importing USGS HANS volcano alerts..."
+                  node addons/ve-geology/import/import-hans.js \
+                    --data-dir "$DATA_DIR"
+                  echo "Refresh complete."
+              volumeMounts:
+                - name: data
+                  mountPath: /app/data
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "256Mi"
+                limits:
+                  cpu: "1000m"
+                  memory: "1Gi"
+          volumes:
+            - name: data
+              hostPath:
+                path: /mnt/tank/jims/data/systems/geohazardwatch
+                type: DirectoryOrCreate

--- a/apps/production/geohazardwatch/deployment.yaml
+++ b/apps/production/geohazardwatch/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: geohazardwatch
+  namespace: geohazardwatch
+  labels:
+    app: geohazardwatch
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: geohazardwatch
+  template:
+    metadata:
+      labels:
+        app: geohazardwatch
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: geohazardwatch
+          image: ghcr.io/jwilleke/geohazardwatch:1.0.1 # {"$imagepolicy": "flux-system:geohazardwatch"}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: HEADLESS_INSTALL
+              value: "true"
+            - name: INSTANCE_DATA_FOLDER
+              value: "/app/data"
+            - name: SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: geohazardwatch-secrets
+                  key: session-secret
+                  optional: true
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+            - name: config
+              mountPath: /app/data/config/app-custom-config.json
+              subPath: app-custom-config.json
+              readOnly: true
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: data
+          hostPath:
+            path: /mnt/tank/jims/data/systems/geohazardwatch
+            type: DirectoryOrCreate
+        - name: config
+          configMap:
+            name: geohazardwatch-config
+            items:
+              - key: app-custom-config.json
+                path: app-custom-config.json
+      restartPolicy: Always

--- a/apps/production/geohazardwatch/deployment.yaml
+++ b/apps/production/geohazardwatch/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: geohazardwatch
-          image: ghcr.io/jwilleke/geohazardwatch:1.0.1 # {"$imagepolicy": "flux-system:geohazardwatch"}
+          image: ghcr.io/jwilleke/geohazardwatch:1.1.2 # {"$imagepolicy": "flux-system:geohazardwatch"}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/apps/production/geohazardwatch/image-policy.yaml
+++ b/apps/production/geohazardwatch/image-policy.yaml
@@ -1,0 +1,48 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: geohazardwatch
+  namespace: flux-system
+spec:
+  image: ghcr.io/jwilleke/geohazardwatch
+  interval: 10m
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: geohazardwatch
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: geohazardwatch
+  policy:
+    semver:
+      # Auto-update minor and patch within the current major.
+      # Bumping past the next major requires updating this range manually.
+      range: ">=1.0.0 <2.0.0"
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: geohazardwatch
+  namespace: flux-system
+spec:
+  interval: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  git:
+    checkout:
+      ref:
+        branch: master
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        chore(image-automation): bump geohazardwatch to {{range .Updated.Images}}{{.}} {{end}}
+    push:
+      branch: master
+  update:
+    path: ./apps/production/geohazardwatch
+    strategy: Setters

--- a/apps/production/geohazardwatch/ingress.yaml
+++ b/apps/production/geohazardwatch/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: geohazardwatch
+  namespace: geohazardwatch
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - geohazardwatch.nerdsbythehour.com
+      secretName: geohazardwatch-tls
+  rules:
+    - host: geohazardwatch.nerdsbythehour.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: geohazardwatch
+                port:
+                  number: 80

--- a/apps/production/geohazardwatch/kustomization.yaml
+++ b/apps/production/geohazardwatch/kustomization.yaml
@@ -9,4 +9,9 @@ resources:
   - ingress.yaml
   - certificate.yaml
   - cronjob-import.yaml
-  - image-policy.yaml
+  # image-policy.yaml is intentionally NOT in this list yet.
+  # The production cluster's Flux is bootstrapped without
+  # image-reflector-controller / image-automation-controller, so the
+  # ImageRepository / ImagePolicy / ImageUpdateAutomation CRDs do not
+  # exist. Bootstrap those controllers first (see README), then add
+  # `- image-policy.yaml` here to enable auto-updates.

--- a/apps/production/geohazardwatch/kustomization.yaml
+++ b/apps/production/geohazardwatch/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: geohazardwatch
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - certificate.yaml
+  - cronjob-import.yaml
+  - image-policy.yaml

--- a/apps/production/geohazardwatch/namespace.yaml
+++ b/apps/production/geohazardwatch/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: geohazardwatch

--- a/apps/production/geohazardwatch/service.yaml
+++ b/apps/production/geohazardwatch/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: geohazardwatch
+  namespace: geohazardwatch
+  labels:
+    app: geohazardwatch
+spec:
+  type: ClusterIP
+  selector:
+    app: geohazardwatch
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+      protocol: TCP

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -25,3 +25,4 @@ resources:
   - ./home-assistant-proxy
   - ./jimsmcp        # MCP server for custom infrastructure features
   - ./jimstest       # ngdpbase dev/test instance on jminm4
+  - ./geohazardwatch # ngdpbase + ve-geology addon at geohazardwatch.com

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -38,6 +38,18 @@ See [docs/planning/TODO.md](./docs/planning/TODO.md) for task planning, [CHANGEL
 - 2025-12-11-01 - Added zero-threat.html static page - "Create unprotected zero-threat.html page on landing page"
 - 2025-12-11-02 - Security vulnerability analysis and remediation plan - "Analyze ZeroThreat security scan and create SECURITY.md"
 
+## 2026-05-07-02
+
+- Agent: Claude Opus 4.7
+- Subject: Bump geohazardwatch image tag from 1.0.1 to 1.1.2
+- Work Done:
+  - First publishable image of `ghcr.io/jwilleke/geohazardwatch` is `1.1.2` (1.0.1 was a placeholder; 1.1.0 and 1.1.1 publish workflows failed for separate reasons — see `jwilleke/geohazardwatch` CHANGELOG).
+  - Bumped `image:` tag in `deployment.yaml` and `cronjob-import.yaml` to `1.1.2` so the manifest references a real image.
+- Files Modified:
+  - apps/production/geohazardwatch/deployment.yaml
+  - apps/production/geohazardwatch/cronjob-import.yaml
+  - docs/project_log.md (this file)
+
 ## 2026-05-07-01
 
 - Agent: Claude Opus 4.7

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -23,6 +23,7 @@ See [docs/planning/TODO.md](./docs/planning/TODO.md) for task planning, [CHANGEL
 
 ## Work Completed
 
+- 2026-05-07-01 - Add geohazardwatch app with Flux image automation
 - 2026-01-29-01 - Fix Flux reconciliation and Home Assistant authentication
 - 2026-01-22-05 - Attempt amdwiki fix, created upstream issue
 - 2026-01-22-04 - Fix Dependabot security vulnerabilities in jimsmcp
@@ -36,6 +37,25 @@ See [docs/planning/TODO.md](./docs/planning/TODO.md) for task planning, [CHANGEL
 - 2025-12-10-01 - Fixed Home Assistant proxy DNS and WebSocket - "Diagnose and fix ha.nerdsbythehour.com connectivity"
 - 2025-12-11-01 - Added zero-threat.html static page - "Create unprotected zero-threat.html page on landing page"
 - 2025-12-11-02 - Security vulnerability analysis and remediation plan - "Analyze ZeroThreat security scan and create SECURITY.md"
+
+## 2026-05-07-01
+
+- Agent: Claude Opus 4.7
+- Subject: Add `geohazardwatch` app with image automation
+- Key Decision: Bypass Traefik on the public path. The Cloudflare Tunnel will target the `geohazardwatch` Service directly (decided in `jwilleke/geohazardwatch#14`); Traefik IngressRoute is kept only for internal LAN verification on `geohazardwatch.nerdsbythehour.com`.
+- Work Done:
+  - Created `apps/production/geohazardwatch/` (namespace, configmap, deployment, service, ingress, certificate, cronjob-import, image-policy, kustomization, README).
+  - Used hostPath `/mnt/tank/jims/data/systems/geohazardwatch` for `/app/data` (matches jimswiki convention; avoids `wiki` in the path per operator preference).
+  - ngdpbase configured via ConfigMap to set addons-path `/opt/geohazardwatch/addons` and enable the `ve-geology` addon with `dataPath: /app/data/ve-geology`.
+  - Added Flux `ImageRepository` + `ImagePolicy` (semver `>=1.0.0 <2.0.0`) + `ImageUpdateAutomation` watching `ghcr.io/jwilleke/geohazardwatch`. Auto-bumps minor/patch; majors require manual `range` widening.
+  - Nightly `CronJob` runs `import-volcanoes`, `import-earthquakes`, `import-hans` against `/app/data/ve-geology` at 08:00 UTC.
+  - Registered app in `apps/production/kustomization.yaml`.
+  - Pairs with `jwilleke/geohazardwatch#19` which adds the Dockerfile + image-publish workflow + Renovate.
+- Files Modified:
+  - `apps/production/geohazardwatch/*` (10 new files)
+  - `apps/production/kustomization.yaml`
+  - `docs/project_log.md` (this file)
+- Follow-up: Cloudflare Tunnel wiring (`jwilleke/geohazardwatch#15-18`) — only after the site is verifiable on the LAN.
 
 ## 2026-01-29-01
 

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -47,7 +47,7 @@ See [docs/planning/TODO.md](./docs/planning/TODO.md) for task planning, [CHANGEL
   - Created `apps/production/geohazardwatch/` (namespace, configmap, deployment, service, ingress, certificate, cronjob-import, image-policy, kustomization, README).
   - Used hostPath `/mnt/tank/jims/data/systems/geohazardwatch` for `/app/data` (matches jimswiki convention; avoids `wiki` in the path per operator preference).
   - ngdpbase configured via ConfigMap to set addons-path `/opt/geohazardwatch/addons` and enable the `ve-geology` addon with `dataPath: /app/data/ve-geology`.
-  - Added Flux `ImageRepository` + `ImagePolicy` (semver `>=1.0.0 <2.0.0`) + `ImageUpdateAutomation` watching `ghcr.io/jwilleke/geohazardwatch`. Auto-bumps minor/patch; majors require manual `range` widening.
+  - Drafted Flux `ImageRepository` + `ImagePolicy` (semver `>=1.0.0 <2.0.0`) + `ImageUpdateAutomation` in `image-policy.yaml`, but **NOT** added to the kustomization yet — the production cluster's Flux was bootstrapped without `image-reflector-controller` / `image-automation-controller`, so the CRDs don't exist. Bootstrap step documented in the app's README; once added, enable by uncommenting the resource line.
   - Nightly `CronJob` runs `import-volcanoes`, `import-earthquakes`, `import-hans` against `/app/data/ve-geology` at 08:00 UTC.
   - Registered app in `apps/production/kustomization.yaml`.
   - Pairs with `jwilleke/geohazardwatch#19` which adds the Dockerfile + image-publish workflow + Renovate.


### PR DESCRIPTION
## Summary

- Adds `apps/production/geohazardwatch/` — ngdpbase + ve-geology addon at `geohazardwatch.com`.
- Public path will go through **Cloudflare Tunnel direct to the Service** (bypassing Traefik). Traefik IngressRoute included only for internal LAN verification on `geohazardwatch.nerdsbythehour.com`.
- Wires up Flux image automation **behind a one-time bootstrap step** (see caveat below).

## Scope

This PR only adds new resources in a new namespace (`geohazardwatch`) plus a single line in `apps/production/kustomization.yaml`. No changes to other apps.

## ⚠️ Image automation needs a one-time Flux bootstrap

The production cluster's `flux-system` was bootstrapped with only `source-controller,kustomize-controller,helm-controller,notification-controller`. The image-automation CRDs (`ImageRepository` / `ImagePolicy` / `ImageUpdateAutomation`) are **not installed**.

`image-policy.yaml` is committed to the repo but **deliberately excluded from `kustomization.yaml`** — leaving it in would make the Flux Kustomization fail to reconcile.

To enable auto-deploys, run:

```bash
flux bootstrap github \
  --owner=jwilleke \
  --repository=mj-infra-flux \
  --branch=master \
  --path=clusters/production \
  --components-extra=image-reflector-controller,image-automation-controller
```

Then uncomment the `- image-policy.yaml` line in `apps/production/geohazardwatch/kustomization.yaml`.

Until that's done, image bumps are manual edits to the `image:` line in `deployment.yaml` + `cronjob-import.yaml`. Renovate on `jwilleke/geohazardwatch` still works; only the in-cluster auto-deploy step is gated.

## What's included

| File | Purpose |
| --- | --- |
| `namespace.yaml` | New `geohazardwatch` namespace |
| `configmap.yaml` | `app-custom-config.json` — addons-path `/opt/geohazardwatch/addons`, enables `ve-geology` addon, dataPath on persistent volume |
| `deployment.yaml` | ngdpbase pod, image pinned to `ghcr.io/jwilleke/geohazardwatch:1.0.1`, headless install, hostPath `/mnt/tank/jims/data/systems/geohazardwatch` for `/app/data` |
| `service.yaml` | ClusterIP 80 → 3000 |
| `ingress.yaml` | Traefik IngressRoute for LAN at `geohazardwatch.nerdsbythehour.com` |
| `certificate.yaml` | cert-manager Let's Encrypt cert for the LAN host |
| `cronjob-import.yaml` | Nightly volcano/quake/HANS data refresh at 08:00 UTC |
| `image-policy.yaml` | Flux image-automation triplet (NOT in kustomization yet — needs bootstrap) |
| `kustomization.yaml` | Wires the resources together |
| `README.md` | App-specific operator docs (incl. bootstrap steps) |

Plus one line in `apps/production/kustomization.yaml` to register the app.

## Test plan

- [ ] `kustomize build apps/production/geohazardwatch/` renders cleanly.
- [ ] Flux reconciles the new Kustomization without errors.
- [ ] Pod becomes Ready; `kubectl logs` shows ngdpbase booting and ve-geology addon registered.
- [ ] `https://geohazardwatch.nerdsbythehour.com/` returns the wiki home page on the LAN.
- [ ] One-shot data import succeeds: `kubectl -n geohazardwatch create job --from=cronjob/geohazardwatch-data-refresh initial-import`.
- [ ] After bootstrap: `flux -n flux-system get image policy geohazardwatch` shows the policy resolving the current tag.
- [ ] After verification: wire up the Cloudflare Tunnel (`jwilleke/geohazardwatch#15-18`).

## Pairs with

- `jwilleke/geohazardwatch#19` — Dockerfile, publish workflow, Renovate.

## Follow-ups (after merge)

- Re-bootstrap `flux-system` with `image-reflector-controller,image-automation-controller`, then uncomment `- image-policy.yaml` in this app's `kustomization.yaml`.
- Cloudflare Tunnel: target `Service/geohazardwatch.geohazardwatch.svc.cluster.local:80` directly. See `jwilleke/geohazardwatch#14-18`.
- Optional: SOPS-encrypted `geohazardwatch-secrets` with a real session secret.
- Optional: Authentik ForwardAuth on the internal LAN ingress (matches jimswiki TODO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)