### PR TITLE
fix(geohazardwatch): scan both built-in and external addon dirs

### DIFF
--- a/apps/production/geohazardwatch/configmap.yaml
+++ b/apps/production/geohazardwatch/configmap.yaml
@@ -12,7 +12,7 @@ data:
       "ngdpbase.application-name": "GeoHazardWatch",
       "ngdpbase.session.secure": true,
       "ngdpbase.session.sameSite": "lax",
-      "ngdpbase.managers.addons-manager.addons-path": "/opt/geohazardwatch/addons",
+      "ngdpbase.managers.addons-manager.addons-path": ["/app/addons", "/opt/geohazardwatch/addons"],
       "ngdpbase.addons.ve-geology.enabled": true,
       "ngdpbase.addons.ve-geology.dataPath": "/app/data/ve-geology"
     }

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -38,6 +38,18 @@ See [docs/planning/TODO.md](./docs/planning/TODO.md) for task planning, [CHANGEL
 - 2025-12-11-01 - Added zero-threat.html static page - "Create unprotected zero-threat.html page on landing page"
 - 2025-12-11-02 - Security vulnerability analysis and remediation plan - "Analyze ZeroThreat security scan and create SECURITY.md"
 
+## 2026-05-07-03
+
+- Agent: Claude Opus 4.7
+- Subject: Fix geohazardwatch addons-path so built-in ngdpbase addons keep loading
+- Key Decision: Use array form for `ngdpbase.managers.addons-manager.addons-path`. ngdpbase's `AddonsManager` accepts either a string or an array, but a string REPLACES the default `./addons`, killing the built-in addon scan. Array preserves built-ins AND adds the external geohazardwatch addon.
+- Work Done:
+  - Changed `ngdpbase.managers.addons-manager.addons-path` from `"/opt/geohazardwatch/addons"` to `["/app/addons", "/opt/geohazardwatch/addons"]`.
+  - Verified the behaviour by reading `src/managers/AddonsManager.ts` in the upstream `ngdpbase` repo (lines 208-219): the value is split on whether it's `Array.isArray()`, single strings replace; arrays scan all entries.
+- Files Modified:
+  - apps/production/geohazardwatch/configmap.yaml
+  - docs/project_log.md (this file)
+
 ## 2026-05-07-02
 
 - Agent: Claude Opus 4.7


### PR DESCRIPTION
## Summary

`ngdpbase.managers.addons-manager.addons-path` accepts either a string or an array. As a string it **replaces** the default `./addons` (which is `/app/addons` in the container) — so the built-in addon scan stops, and only the external dir is scanned.

If the external scan finds nothing or fails silently, the wiki boots with **zero addons** (which is what we observed: 500-line log tail, no addon-related lines).

## Fix

Use the array form so both directories are scanned:

```diff
-      "ngdpbase.managers.addons-manager.addons-path": "/opt/geohazardwatch/addons",
+      "ngdpbase.managers.addons-manager.addons-path": ["/app/addons", "/opt/geohazardwatch/addons"],
```

Verified against the upstream `ngdpbase` source — `src/managers/AddonsManager.ts` lines 208-219:

```ts
const raw = configManager.getProperty(
  'ngdpbase.managers.addons-manager.addons-path',
  './addons'
);
this.addonsPaths = Array.isArray(raw)
  ? (raw as string[]).map(String)
  : [String(raw)];
```

A string ends up as a single-element array; an array of strings keeps every entry.

## Test plan

- [ ] Merge.
- [ ] `flux -n flux-system reconcile kustomization apps --with-source`.
- [ ] `kubectl rollout restart deploy/geohazardwatch -n geohazardwatch` (so the new ConfigMap is picked up — the existing pod won't reload it on its own).
- [ ] Boot logs should show `Initialized with N add-on(s) discovered, M loaded` and the `ve-geology` addon registering.
- [ ] `kubectl create job --from=cronjob/geohazardwatch-data-refresh initial-import` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)