### PR TITLE
chore(geohazardwatch): bump image tag 1.1.2 -> 1.1.3

### DIFF
--- a/apps/production/geohazardwatch/cronjob-import.yaml
+++ b/apps/production/geohazardwatch/cronjob-import.yaml
@@ -19,7 +19,7 @@ spec:
             fsGroup: 1000
           containers:
             - name: import
-              image: ghcr.io/jwilleke/geohazardwatch:1.1.2 # {"$imagepolicy": "flux-system:geohazardwatch"}
+              image: ghcr.io/jwilleke/geohazardwatch:1.1.3 # {"$imagepolicy": "flux-system:geohazardwatch"}
               imagePullPolicy: IfNotPresent
               workingDir: /opt/geohazardwatch
               command:

--- a/apps/production/geohazardwatch/deployment.yaml
+++ b/apps/production/geohazardwatch/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: geohazardwatch
-          image: ghcr.io/jwilleke/geohazardwatch:1.1.2 # {"$imagepolicy": "flux-system:geohazardwatch"}
+          image: ghcr.io/jwilleke/geohazardwatch:1.1.3 # {"$imagepolicy": "flux-system:geohazardwatch"}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -38,6 +38,17 @@ See [docs/planning/TODO.md](./docs/planning/TODO.md) for task planning, [CHANGEL
 - 2025-12-11-01 - Added zero-threat.html static page - "Create unprotected zero-threat.html page on landing page"
 - 2025-12-11-02 - Security vulnerability analysis and remediation plan - "Analyze ZeroThreat security scan and create SECURITY.md"
 
+## 2026-05-07-04
+
+- Agent: Claude Opus 4.7
+- Subject: Bump geohazardwatch image tag 1.1.2 → 1.1.3
+- Work Done:
+  - Bumped `image:` tag in `deployment.yaml` and `cronjob-import.yaml` to `1.1.3` to pick up `geohazardwatch#24` — fix for placeholder UUIDs on seed pages so the wiki actually has content.
+- Files Modified:
+  - apps/production/geohazardwatch/deployment.yaml
+  - apps/production/geohazardwatch/cronjob-import.yaml
+  - docs/project_log.md (this file)
+
 ## 2026-05-07-03
 
 - Agent: Claude Opus 4.7


### PR DESCRIPTION
## Summary

Picks up `jwilleke/geohazardwatch#24` — placeholder seed-page UUIDs replaced with real UUID v4 values so `AddonsManager` actually seeds the eight `ve-geology-*` wiki pages on first boot. Without this bump, the wiki has zero geology content.

## Sequence

1. `geohazardwatch#24` was merged, `v1.1.3` tagged.
2. **Wait for `Publish container image` (run [25501462525](https://github.com/jwilleke/geohazardwatch/actions/runs/25501462525)) to finish green and `ghcr.io/jwilleke/geohazardwatch:1.1.3` to appear in the registry** before merging this PR.
3. Then merge → `flux reconcile` → `kubectl rollout restart deploy/geohazardwatch -n geohazardwatch` → confirm seeded pages.

## What changes

```diff
-          image: ghcr.io/jwilleke/geohazardwatch:1.1.2 # {"$imagepolicy": "flux-system:geohazardwatch"}
+          image: ghcr.io/jwilleke/geohazardwatch:1.1.3 # {"$imagepolicy": "flux-system:geohazardwatch"}
```

In both `deployment.yaml` and `cronjob-import.yaml`. Once Flux image automation is bootstrapped, future bumps will be auto-PRed by Flux instead of done by hand.

## Test plan

- [ ] Confirm `ghcr.io/jwilleke/geohazardwatch:1.1.3` is published before merge.
- [ ] After merge + reconcile + restart: `kubectl logs -l app=geohazardwatch | grep -i seed` should show successfully seeded pages, and there should be **no** "Skipping … missing or invalid uuid" warnings.
- [ ] `kubectl exec deploy/geohazardwatch -- ls /app/data/pages/ | wc -l` should jump by 8 (the seeded pages).
- [ ] `https://geohazardwatch.nerdsbythehour.com/wiki/volcanoes-and-earthquakes` should render (the addon home page slug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)