### PR TITLE
fix(geohazardwatch): set dnsConfig ndots:1 to fix external DNS

### DIFF
--- a/apps/production/geohazardwatch/cronjob-import.yaml
+++ b/apps/production/geohazardwatch/cronjob-import.yaml
@@ -17,6 +17,12 @@ spec:
           restartPolicy: OnFailure
           securityContext:
             fsGroup: 1000
+          # See deployment.yaml — Alpine musl needs ndots:1 so external
+          # hostnames resolve correctly via getaddrinfo.
+          dnsConfig:
+            options:
+              - name: ndots
+                value: "1"
           containers:
             - name: import
               image: ghcr.io/jwilleke/geohazardwatch:1.1.3 # {"$imagepolicy": "flux-system:geohazardwatch"}

--- a/apps/production/geohazardwatch/deployment.yaml
+++ b/apps/production/geohazardwatch/deployment.yaml
@@ -22,6 +22,13 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
+      # Alpine musl + k8s default ndots:5 breaks getaddrinfo for external
+      # hostnames (search-list expansion misfires). Override ndots so the
+      # resolver treats any name with at least one dot as absolute first.
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       containers:
         - name: geohazardwatch
           image: ghcr.io/jwilleke/geohazardwatch:1.1.3 # {"$imagepolicy": "flux-system:geohazardwatch"}

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -38,6 +38,24 @@ See [docs/planning/TODO.md](./docs/planning/TODO.md) for task planning, [CHANGEL
 - 2025-12-11-01 - Added zero-threat.html static page - "Create unprotected zero-threat.html page on landing page"
 - 2025-12-11-02 - Security vulnerability analysis and remediation plan - "Analyze ZeroThreat security scan and create SECURITY.md"
 
+## 2026-05-07-05
+
+- Agent: Claude Opus 4.7
+- Subject: Fix geohazardwatch DNS resolution for external hostnames (ndots:1)
+- Key Decision: Override `ndots:5` (k8s default) to `ndots:1` via `dnsConfig` on both the Deployment and CronJob pod specs.
+- Symptom: Initial data-import job (`/api/ve-geology/*` data sources at `webservices.volcano.si.edu`, `earthquake.usgs.gov`, etc.) failed with bare `Import failed: fetch failed` — Node's undici error message hides the underlying cause.
+- Diagnosis:
+  - Spawned a one-shot `curlimages/curl` pod in the `geohazardwatch` namespace.
+  - `nslookup webservices.volcano.si.edu` resolved correctly via cluster DNS (10.43.0.10).
+  - `curl https://webservices.volcano.si.edu/` failed with `Could not resolve host`.
+  - `curl https://webservices.volcano.si.edu./` (trailing dot, FQDN) returned HTTP 404 — i.e. server reachable.
+  - Conclusion: Alpine musl `getaddrinfo` mis-handles k8s `/etc/resolv.conf` `search` directive under the default `ndots:5`. The geohazardwatch image is FROM `ghcr.io/jwilleke/ngdpbase` which is FROM `node:20-alpine`. The wiki engine itself doesn't make outbound HTTPS so the issue stayed hidden until the import ran.
+- Fix: Added `dnsConfig.options.ndots: "1"` to both the Deployment and CronJob pod specs. With ndots:1, any name containing at least one dot (all external hostnames) is treated as absolute first, skipping the broken search-list expansion.
+- Files Modified:
+  - apps/production/geohazardwatch/deployment.yaml
+  - apps/production/geohazardwatch/cronjob-import.yaml
+  - docs/project_log.md (this file)
+
 ## 2026-05-07-04
 
 - Agent: Claude Opus 4.7


### PR DESCRIPTION
## Summary

Initial data-import job for `geohazardwatch` failed with a bare `Import failed: fetch failed`. Tracked it down to Alpine musl + k8s `ndots:5` interaction breaking `getaddrinfo()` for external hostnames.

## Diagnosis

Spawned a one-shot `curlimages/curl` pod in the namespace:

```
$ nslookup webservices.volcano.si.edu       # cluster DNS resolver
Server:		10.43.0.10
Address: 160.111.244.27                     # ✅ resolves

$ curl https://webservices.volcano.si.edu/  # libc getaddrinfo
curl: (6) Could not resolve host: webservices.volcano.si.edu

$ curl https://webservices.volcano.si.edu./ # trailing-dot FQDN
HTTP 200/404                                # ✅ reachable
```

So the cluster DNS server is fine; it's libc's resolver that misfires on the search-list expansion. The geohazardwatch image is `FROM node:20-alpine` (via `ghcr.io/jwilleke/ngdpbase`), and Alpine's musl libc has known issues with k8s's `ndots:5` default + parallel A/AAAA queries to CoreDNS.

## Fix

Added to both the Deployment and the CronJob pod specs:

```yaml
dnsConfig:
  options:
    - name: ndots
      value: "1"
```

With `ndots:1`, any hostname containing at least one dot (`webservices.volcano.si.edu`, `earthquake.usgs.gov`, etc.) is treated as absolute first — the broken search-list expansion is skipped. Cluster-internal short names (`servicename`) still resolve via search list since they have zero dots.

## Test plan

- [ ] Merge.
- [ ] `flux reconcile kustomization apps --with-source`.
- [ ] `kubectl rollout restart deploy/geohazardwatch -n geohazardwatch`.
- [ ] `kubectl create job --from=cronjob/geohazardwatch-data-refresh initial-import-$(date +%s)` should now reach all three data sources (GVP, USGS earthquakes, USGS HANS) and complete successfully.
- [ ] `/api/ve-geology/search?limit=1` returns volcano data.

## Related

Issue surfaced in [`mj-infra-flux#48`](https://github.com/jwilleke/mj-infra-flux/pull/48) deployment after the v1.1.3 image went live. The wiki engine itself runs fine — it just doesn't make outbound HTTPS during normal operation, so the DNS misconfiguration only bit the import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)