### PR TITLE
fix(geohazardwatch): theme + front-page + versioning page provider

### DIFF
--- a/apps/production/geohazardwatch/configmap.yaml
+++ b/apps/production/geohazardwatch/configmap.yaml
@@ -12,6 +12,9 @@ data:
       "ngdpbase.application-name": "GeoHazardWatch",
       "ngdpbase.session.secure": true,
       "ngdpbase.session.sameSite": "lax",
+      "ngdpbase.page.provider": "versioningfileprovider",
+      "ngdpbase.theme.active": "volcano",
+      "ngdpbase.front-page": "volcanoes-and-earthquakes",
       "ngdpbase.managers.addons-manager.addons-path": ["/app/addons", "/opt/geohazardwatch/addons"],
       "ngdpbase.addons.ve-geology.enabled": true,
       "ngdpbase.addons.ve-geology.dataPath": "/app/data/ve-geology"

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -38,6 +38,21 @@ See [docs/planning/TODO.md](./docs/planning/TODO.md) for task planning, [CHANGEL
 - 2025-12-11-01 - Added zero-threat.html static page - "Create unprotected zero-threat.html page on landing page"
 - 2025-12-11-02 - Security vulnerability analysis and remediation plan - "Analyze ZeroThreat security scan and create SECURITY.md"
 
+## 2026-05-07-06
+
+- Agent: Claude Opus 4.7
+- Subject: Port working theme/front-page/page-provider config from local instance to cluster
+- Symptom: Site logged in as admin, but couldn't edit pages, used the wrong theme, and addon plugins didn't render. Same code worked correctly on the local jminm4 ngdpbase instance at localhost:3333.
+- Diagnosis: Diffed cluster `app-custom-config.json` against the local working `data/config/app-custom-config.json` in the ngdpbase clone. Three production-relevant settings were missing.
+- Fix: Added to the cluster ConfigMap:
+  - `ngdpbase.theme.active: "volcano"` (was defaulting to `default` theme)
+  - `ngdpbase.front-page: "volcanoes-and-earthquakes"` (was defaulting to `Welcome`)
+  - `ngdpbase.page.provider: "versioningfileprovider"` (was defaulting to `filesystemprovider`; versioning provider supports the full editing UI and history)
+- Did NOT port (environment-specific or sensitive): port 3333, local addons path, base-url, session secret (belongs in SOPS Secret), local backup dir, organization metadata.
+- Files Modified:
+  - apps/production/geohazardwatch/configmap.yaml
+  - docs/project_log.md (this file)
+
 ## 2026-05-07-05
 
 - Agent: Claude Opus 4.7


### PR DESCRIPTION
## Summary

Site was logged in as admin but couldn't edit pages, used the wrong theme, and addon plugins didn't render. Same code works on the local jminm4 instance.

## Root cause

The cluster ConfigMap was a minimal hand-rolled config. The working local `app-custom-config.json` had three production-relevant settings that weren't ported:

| Key | Was | Now |
|---|---|---|
| `ngdpbase.theme.active` | `default` (implicit) | `volcano` |
| `ngdpbase.front-page` | `Welcome` (implicit) | `volcanoes-and-earthquakes` |
| `ngdpbase.page.provider` | `filesystemprovider` (implicit) | `versioningfileprovider` |

- **`versioningfileprovider`** is what supports the full editing UI plus page history. The default `filesystemprovider` is more restricted — likely the cause of the edit issue.
- **`front-page: volcanoes-and-earthquakes`** replaces the ngdpbase boilerplate `Welcome` redirect with the seeded ve-geology home page.
- **`theme.active: volcano`** applies the volcano-themed CSS + favicon shipped with `ngdpbase`.

## Did NOT port

These are env-specific or sensitive and shouldn't go in the public ConfigMap:

- Local port `3333`, local addons path, dev `base-url`
- Session secret (should live in a SOPS-encrypted Secret — separate follow-up)
- Local backup directory `/Volumes/jims/...`
- Organization metadata (already differs between deployments)

## Test plan

- [ ] Merge.
- [ ] `flux reconcile`, `kubectl rollout restart deploy/geohazardwatch`.
- [ ] Hit `https://geohazardwatch.nerdsbythehour.com/` — should land on `volcanoes-and-earthquakes` (not `/view/Welcome`), styled with volcano theme.
- [ ] Log in as admin and confirm Edit button works on a seeded page.
- [ ] Plugins on `volcanoes-and-earthquakes` and `earthquakes` pages should render (volcano list, map, etc.) instead of raw markup.

## Follow-up

- Migrate session secret to a SOPS-encrypted Secret. Currently the deployment.yaml references `geohazardwatch-secrets` with `optional: true`, so the pod runs without one — sessions don't survive pod restarts.
- After this lands and the cluster is verified, plan to merge with the original epic (Cloudflare Tunnel #14-18 in the geohazardwatch repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)