### PR TITLE
chore(geohazardwatch): bump image tag 1.1.3 -> 1.1.4 (ngdpbase 3.10.1)

### DIFF
--- a/apps/production/geohazardwatch/cronjob-import.yaml
+++ b/apps/production/geohazardwatch/cronjob-import.yaml
@@ -25,7 +25,7 @@ spec:
                 value: "1"
           containers:
             - name: import
-              image: ghcr.io/jwilleke/geohazardwatch:1.1.3 # {"$imagepolicy": "flux-system:geohazardwatch"}
+              image: ghcr.io/jwilleke/geohazardwatch:1.1.4 # {"$imagepolicy": "flux-system:geohazardwatch"}
               imagePullPolicy: IfNotPresent
               workingDir: /opt/geohazardwatch
               command:

--- a/apps/production/geohazardwatch/deployment.yaml
+++ b/apps/production/geohazardwatch/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             value: "1"
       containers:
         - name: geohazardwatch
-          image: ghcr.io/jwilleke/geohazardwatch:1.1.3 # {"$imagepolicy": "flux-system:geohazardwatch"}
+          image: ghcr.io/jwilleke/geohazardwatch:1.1.4 # {"$imagepolicy": "flux-system:geohazardwatch"}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -38,6 +38,18 @@ See [docs/planning/TODO.md](./docs/planning/TODO.md) for task planning, [CHANGEL
 - 2025-12-11-01 - Added zero-threat.html static page - "Create unprotected zero-threat.html page on landing page"
 - 2025-12-11-02 - Security vulnerability analysis and remediation plan - "Analyze ZeroThreat security scan and create SECURITY.md"
 
+## 2026-05-07-07
+
+- Agent: Claude Opus 4.7
+- Subject: Bump geohazardwatch image tag 1.1.3 → 1.1.4
+- Work Done:
+  - Picks up `jwilleke/geohazardwatch#25` which bumps the base ngdpbase image to 3.10.1.
+  - 3.10 is the first ngdpbase release that creates `OrganizationRole` records on headless install, which is required for the seeded `admin` user to actually carry the `admin` role at login — without it, the cluster's admin user resolved to `Anonymous|All` and saw no Edit button or admin dashboard.
+- Files Modified:
+  - apps/production/geohazardwatch/deployment.yaml
+  - apps/production/geohazardwatch/cronjob-import.yaml
+  - docs/project_log.md (this file)
+
 ## 2026-05-07-06
 
 - Agent: Claude Opus 4.7


### PR DESCRIPTION
## Summary

Picks up `jwilleke/geohazardwatch#25` which rebases on `ghcr.io/jwilleke/ngdpbase:3.10.1`.

## Why this matters

3.10 introduced `OrganizationRole`-based role assignment (per `ngdpbase` `User.ts:78` deprecation note for the legacy `roles[]` field). The headless install path on 3.10 creates the role records that `UserManager.resolveUserRoles(username)` needs.

Without that (3.9.x), the cluster's headless-installed `admin` user resolved to `Anonymous|All`. Symptom:
- ACL log showed `user=Anonymous roles=Anonymous|All` for an authenticated admin session
- No Edit button on pages, no admin dashboard, even in fresh incognito sessions
- `/app/data/roles/` and `/app/data/organizations/` were empty in the pod

## Wait for the image

`Publish container image` workflow run for `v1.1.4` is in progress (https://github.com/jwilleke/geohazardwatch/actions/runs/25506130627). Don't merge this PR until it succeeds and `ghcr.io/jwilleke/geohazardwatch:1.1.4` is in the registry.

## Test plan

- [ ] Confirm `ghcr.io/jwilleke/geohazardwatch:1.1.4` published.
- [ ] Merge.
- [ ] `flux reconcile`, `kubectl rollout restart deploy/geohazardwatch`.
- [ ] Page header now reads `v3.10.1`.
- [ ] Admin login → Edit button + admin dashboard appear.
- [ ] `/app/data/roles/` is populated with role records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)