### PR TITLE
fix(geohazardwatch): pre-seed anchor Organization JSON-LD

### DIFF
--- a/apps/production/geohazardwatch/configmap.yaml
+++ b/apps/production/geohazardwatch/configmap.yaml
@@ -15,7 +15,22 @@ data:
       "ngdpbase.page.provider": "versioningfileprovider",
       "ngdpbase.theme.active": "volcano",
       "ngdpbase.front-page": "volcanoes-and-earthquakes",
+      "ngdpbase.application.organization.file": "geohazardwatch.json",
       "ngdpbase.managers.addons-manager.addons-path": ["/app/addons", "/opt/geohazardwatch/addons"],
       "ngdpbase.addons.ve-geology.enabled": true,
       "ngdpbase.addons.ve-geology.dataPath": "/app/data/ve-geology"
+    }
+  # Anchor Organization JSON-LD record. Required by ngdpbase 3.10+ headless
+  # installs so that UserManager.applyRoleDiff() can bind admin role membership
+  # to a real org @id. Without it, createDefaultAdmin silently skips role
+  # assignment and the seeded admin user resolves to Anonymous|All on every
+  # request. See `ngdpbase` `services/InstallService.ts` and
+  # `managers/UserManager.ts:syncRoleAdd` for the bypass logic.
+  geohazardwatch.json: |
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "@id": "https://geohazardwatch.com",
+      "name": "GeoHazardWatch",
+      "url": "https://geohazardwatch.com"
     }

--- a/apps/production/geohazardwatch/deployment.yaml
+++ b/apps/production/geohazardwatch/deployment.yaml
@@ -57,6 +57,10 @@ spec:
               mountPath: /app/data/config/app-custom-config.json
               subPath: app-custom-config.json
               readOnly: true
+            - name: org
+              mountPath: /app/data/organizations/geohazardwatch.json
+              subPath: geohazardwatch.json
+              readOnly: true
           resources:
             requests:
               cpu: "100m"
@@ -91,4 +95,10 @@ spec:
             items:
               - key: app-custom-config.json
                 path: app-custom-config.json
+        - name: org
+          configMap:
+            name: geohazardwatch-config
+            items:
+              - key: geohazardwatch.json
+                path: geohazardwatch.json
       restartPolicy: Always

--- a/docs/project_log.md
+++ b/docs/project_log.md
@@ -38,6 +38,22 @@ See [docs/planning/TODO.md](./docs/planning/TODO.md) for task planning, [CHANGEL
 - 2025-12-11-01 - Added zero-threat.html static page - "Create unprotected zero-threat.html page on landing page"
 - 2025-12-11-02 - Security vulnerability analysis and remediation plan - "Analyze ZeroThreat security scan and create SECURITY.md"
 
+## 2026-05-07-08
+
+- Agent: Claude Opus 4.7
+- Subject: Pre-seed anchor Organization JSON-LD so ngdpbase 3.10+ can bind admin role
+- Symptom: After bumping geohazardwatch to v1.1.4 (ngdpbase 3.10.1), boot logs showed `Created Person record for admin` and `Created default admin user`, but `/app/data/roles/` and `/app/data/organizations/` remained empty. Admin user still resolved to `Anonymous|All` because no role record was bound.
+- Root cause: `UserManager.applyRoleDiff` calls `syncRoleAdd`, which silently skips when "the install has no anchor org" (per its own JSDoc). 3.10's headless install path explicitly does NOT seed the anchor Organization from config — `services/InstallService.ts:637`: "Operators wanting a pre-seeded anchor org pre-supply the JSON-LD file alongside their custom config."
+- Fix:
+  - Added `geohazardwatch.json` data key to the ConfigMap with the JSON-LD Organization record (`@id: https://geohazardwatch.com`, name `GeoHazardWatch`).
+  - Added `ngdpbase.application.organization.file: "geohazardwatch.json"` to `app-custom-config.json` so OrganizationManager loads it.
+  - Mounted the new key into `/app/data/organizations/geohazardwatch.json` via a second `org` configMap volume + subPath.
+- Follow-up after merge (one-time, on the cluster): scale to 0, sudo-delete `users.json` and the orphaned 3.9-era Person record at `/mnt/tank/jims/data/systems/geohazardwatch/persons/b4de08d8-…json`, scale back to 1. ngdpbase will see zero users, run `createDefaultAdmin`, and bind the admin role to the now-loaded Organization.
+- Files Modified:
+  - apps/production/geohazardwatch/configmap.yaml
+  - apps/production/geohazardwatch/deployment.yaml
+  - docs/project_log.md (this file)
+
 ## 2026-05-07-07
 
 - Agent: Claude Opus 4.7


### PR DESCRIPTION
## Summary

After bumping to geohazardwatch `v1.1.4` (ngdpbase 3.10.1), the seeded admin user still resolved to `Anonymous|All` — no Edit button, no admin dashboard. `/app/data/roles/` was empty even though `createDefaultAdmin` ran successfully.

## Diagnosis chain

Boot logs showed:

```
👤 Created default admin user (username: admin, password: admin123)
📋 Created Person record for admin
```

…but `/app/data/roles/` stayed empty. Per `ngdpbase` source:

- `UserManager.createDefaultAdmin` calls `applyRoleDiff(username, [], ['admin'])`
- `applyRoleDiff` calls `syncRoleAdd` whose JSDoc says: _"Best-effort under degraded init: skips silently when … the install has no anchor org."_
- `services/InstallService.ts:637`: _"Headless installs do NOT seed the anchor org from config (#617): … Operators wanting a pre-seeded anchor org pre-supply the JSON-LD file alongside their custom config."_

So the role assignment was being silently dropped because no Organization existed.

## Fix

Pre-supply the JSON-LD file via the existing ConfigMap:

- New `geohazardwatch.json` data key with the Organization record (`@id: https://geohazardwatch.com`, name `GeoHazardWatch`).
- `app-custom-config.json` gains `ngdpbase.application.organization.file: "geohazardwatch.json"` so OrganizationManager loads it.
- Deployment mounts the new key at `/app/data/organizations/geohazardwatch.json` via a second `org` configMap volume + subPath.

## After merge — one-time cluster cleanup

ngdpbase only runs `createDefaultAdmin` when `users.size === 0`. To get it to re-run with the now-present Organization:

```bash
kubectl -n geohazardwatch scale deploy/geohazardwatch --replicas=0
sudo rm /mnt/tank/jims/data/systems/geohazardwatch/users/users.json
# also remove the orphaned 3.9-era Person record (the one created at 13:42)
sudo rm /mnt/tank/jims/data/systems/geohazardwatch/persons/b4de08d8-*.json
kubectl -n geohazardwatch scale deploy/geohazardwatch --replicas=1
```

I'll do this via SSH after merging.

## Test plan

- [ ] Merge.
- [ ] `flux reconcile` — confirm new ConfigMap key + Deployment mount land.
- [ ] One-time cleanup as above.
- [ ] After rollout: `/app/data/organizations/` contains `geohazardwatch.json` (read-only, from CM mount), `/app/data/roles/` contains `admin.json` (created by `createDefaultAdmin`).
- [ ] Admin login → Edit button + admin dashboard appear.
- [ ] ACL log shows `user=admin roles=admin|Authenticated|All` instead of `user=Anonymous`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)