### PR TITLE
chore(geohazardwatch): bump image tag 1.1.4 -> 1.1.5 (themes fix)

### DIFF
--- a/apps/production/geohazardwatch/cronjob-import.yaml
+++ b/apps/production/geohazardwatch/cronjob-import.yaml
@@ -25,7 +25,7 @@ spec:
                 value: "1"
           containers:
             - name: import
-              image: ghcr.io/jwilleke/geohazardwatch:1.1.4 # {"$imagepolicy": "flux-system:geohazardwatch"}
+              image: ghcr.io/jwilleke/geohazardwatch:1.1.5 # {"$imagepolicy": "flux-system:geohazardwatch"}
               imagePullPolicy: IfNotPresent
               workingDir: /opt/geohazardwatch
               command:

--- a/apps/production/geohazardwatch/deployment.yaml
+++ b/apps/production/geohazardwatch/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             value: "1"
       containers:
         - name: geohazardwatch
-          image: ghcr.io/jwilleke/geohazardwatch:1.1.4 # {"$imagepolicy": "flux-system:geohazardwatch"}
+          image: ghcr.io/jwilleke/geohazardwatch:1.1.5 # {"$imagepolicy": "flux-system:geohazardwatch"}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Picks up jwilleke/geohazardwatch#27 → ngdpbase 3.10.2 → ships the themes/ directory. Fixes geohazardwatch#26.