### PR TITLE
fix(cloudflared): pin to existing image tag 2026.3.0

### DIFF
--- a/apps/production/cloudflared/deployment.yaml
+++ b/apps/production/cloudflared/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             value: "1"
       containers:
         - name: cloudflared
-          image: cloudflare/cloudflared:2026.5.0
+          image: cloudflare/cloudflared:2026.3.0
           imagePullPolicy: IfNotPresent
           args:
             - tunnel


### PR DESCRIPTION
2026.5.0 was a typo — doesn't exist on Docker Hub. Latest is 2026.3.0.