### PR TITLE
fix(flux): enable SOPS decryption on the apps Kustomization

### DIFF
--- a/clusters/deby/apps.yaml
+++ b/clusters/deby/apps.yaml
@@ -16,3 +16,11 @@ spec:
   prune: true
   wait: true
   timeout: 5m0s
+  # SOPS-encrypted secrets in apps/production/<app>/.env.secret.*.encrypted
+  # are decrypted by kustomize-controller using the age key in
+  # `sops-age` (flux-system namespace) before kustomize secretGenerator
+  # turns them into k8s Secrets.
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age


### PR DESCRIPTION
Without this, kustomize-controller passes raw SOPS ciphertext through to secretGenerator. cloudflared was rejecting the bogus token. `flux-system/sops-age` already exists.