### PR TITLE
fix(cloudflared): isolate via dedicated Flux Kustomization

### DIFF
--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -15,7 +15,11 @@ resources:
 
   # Public Applications (Guest Services)
   - ./guest-services
-  - ./cloudflared    # Cloudflare Tunnel connector for geohazardwatch.com
+  # NOTE: cloudflared is NOT here. It runs via its own Flux Kustomization
+  # at clusters/deby/cloudflared.yaml with `decryption: sops` enabled, so
+  # it can decrypt its TUNNEL_TOKEN without forcing the apps Kustomization
+  # to also decrypt the existing monitoring/transmission encrypted files
+  # (which use a different age recipient).
 
   # Public & Protected Applications
   - ./landingpage

--- a/clusters/deby/apps.yaml
+++ b/clusters/deby/apps.yaml
@@ -16,11 +16,3 @@ spec:
   prune: true
   wait: true
   timeout: 5m0s
-  # SOPS-encrypted secrets in apps/production/<app>/.env.secret.*.encrypted
-  # are decrypted by kustomize-controller using the age key in
-  # `sops-age` (flux-system namespace) before kustomize secretGenerator
-  # turns them into k8s Secrets.
-  decryption:
-    provider: sops
-    secretRef:
-      name: sops-age

--- a/clusters/deby/cloudflared.yaml
+++ b/clusters/deby/cloudflared.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudflared
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  # Scoped strictly to the cloudflared app dir so SOPS decryption only
+  # touches files we know are encrypted to the Flux sops-age recipient.
+  # The broader `apps` Kustomization deliberately doesn't enable decryption
+  # because other (legacy) encrypted files in apps/production/ are
+  # encrypted to a different, unavailable age key — see
+  # apps/production/kustomization.yaml comment.
+  path: ./apps/production/cloudflared
+  prune: true
+  wait: true
+  timeout: 5m0s
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age


### PR DESCRIPTION
Pulls SOPS decryption back off the apps Kustomization (other encrypted files under apps/production/ use a different age recipient and break the build), and runs cloudflared via its own Flux Kustomization scoped to ./apps/production/cloudflared with SOPS enabled.