### PR TITLE
feat(geohazardwatch): disable self-registration (v1.1.6)

### DIFF
--- a/apps/production/geohazardwatch/configmap.yaml
+++ b/apps/production/geohazardwatch/configmap.yaml
@@ -12,6 +12,7 @@ data:
       "ngdpbase.application-name": "GeoHazardWatch",
       "ngdpbase.session.secure": true,
       "ngdpbase.session.sameSite": "lax",
+      "ngdpbase.application.registration": false,
       "ngdpbase.page.provider": "versioningfileprovider",
       "ngdpbase.theme.active": "volcano",
       "ngdpbase.front-page": "volcanoes-and-earthquakes",

--- a/apps/production/geohazardwatch/cronjob-import.yaml
+++ b/apps/production/geohazardwatch/cronjob-import.yaml
@@ -25,7 +25,7 @@ spec:
                 value: "1"
           containers:
             - name: import
-              image: ghcr.io/jwilleke/geohazardwatch:1.1.5 # {"$imagepolicy": "flux-system:geohazardwatch"}
+              image: ghcr.io/jwilleke/geohazardwatch:1.1.6 # {"$imagepolicy": "flux-system:geohazardwatch"}
               imagePullPolicy: IfNotPresent
               workingDir: /opt/geohazardwatch
               command:

--- a/apps/production/geohazardwatch/deployment.yaml
+++ b/apps/production/geohazardwatch/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             value: "1"
       containers:
         - name: geohazardwatch
-          image: ghcr.io/jwilleke/geohazardwatch:1.1.5 # {"$imagepolicy": "flux-system:geohazardwatch"}
+          image: ghcr.io/jwilleke/geohazardwatch:1.1.6 # {"$imagepolicy": "flux-system:geohazardwatch"}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Sets ngdpbase.application.registration: false in the ConfigMap and bumps image tag 1.1.5 -> 1.1.6 (Deployment + CronJob). Picks up jwilleke/geohazardwatch#28 / ngdpbase v3.10.3.

After merge: flux reconcile + rollout restart + verify
- GET https://geohazardwatch.com/register → 404
- Header shows 'Request access' linking to /wiki/request-access
- /wiki/request-access renders the seeded contact page