### PR TITLE
fix(geohazardwatch): scaffold image-automation with GHCR secretRef (#64)

### DIFF
--- a/apps/production/geohazardwatch/README.md
+++ b/apps/production/geohazardwatch/README.md
@@ -11,37 +11,20 @@ Built on the [`ngdpbase`](https://github.com/jwilleke/ngdpbase) wiki engine with
 - **Public path**: Cloudflare Tunnel → cluster Service direct (bypasses Traefik). Wired up separately — see geohazardwatch issues #14-18.
 - **Internal path**: Traefik IngressRoute on `geohazardwatch.nerdsbythehour.com` with a cert-manager Let's Encrypt cert. Used to verify the pod independently of the tunnel.
 
-## Auto-update flow (requires one-time bootstrap step)
+## Auto-update flow
 
-The production cluster's Flux currently runs with only the four core controllers (`source`, `kustomize`, `helm`, `notification`). Image automation is **not yet enabled** — `image-reflector-controller` and `image-automation-controller` need to be added before `image-policy.yaml` can be activated.
+The cluster's Flux already runs `image-reflector-controller` and `image-automation-controller` (see `clusters/production/flux-system/gotk-components.yaml`). The Flux pieces that drive auto-updates for this app live one directory over, in [`../image-automation/`](../image-automation/), because they belong in the `flux-system` namespace and this kustomization stamps `namespace: geohazardwatch` on everything it lists.
 
-### One-time bootstrap
+Flow once activated:
 
-Re-run `flux bootstrap` with the extra components, e.g.:
-
-```bash
-flux bootstrap github \
-  --owner=jwilleke \
-  --repository=mj-infra-flux \
-  --branch=master \
-  --path=clusters/production \
-  --components-extra=image-reflector-controller,image-automation-controller
-```
-
-(Or hand-edit `clusters/production/flux-system/gotk-components.yaml` and add the two controllers + their CRDs.)
-
-### Once bootstrapped
-
-1. Add `- image-policy.yaml` to `kustomization.yaml` here.
-2. New `ngdpbase` image published → Renovate (in the `geohazardwatch` repo) opens a PR bumping the base image; minor/patch auto-merge.
-3. Merge to `master` triggers `publish-image.yml` → new `ghcr.io/jwilleke/geohazardwatch:X.Y.Z`.
-4. Flux `ImageRepository` + `ImagePolicy` detect the new tag (semver range `>=1.0.0 <2.0.0`).
-5. `ImageUpdateAutomation` rewrites the `image:` line in `deployment.yaml` and `cronjob-import.yaml` and commits to `master`.
+1. New `ngdpbase` image published → Renovate (in the `geohazardwatch` repo) opens a PR bumping the base image; minor/patch auto-merge.
+2. Merge to `master` triggers `publish-image.yml` → new `ghcr.io/jwilleke/geohazardwatch:X.Y.Z` on GHCR.
+3. The `ImageRepository` (with `secretRef: ghcr-geohazardwatch`) scans GHCR every 10m and exposes the tag list.
+4. The `ImagePolicy` selects the highest tag matching `>=1.0.0 <2.0.0`.
+5. The `ImageUpdateAutomation` rewrites the `# {"$imagepolicy": "flux-system:geohazardwatch"}`-marked `image:` line in `deployment.yaml` (and `cronjob-import.yaml` if marked) and commits to `master` as `fluxcdbot`.
 6. Flux reconciles → rolling deploy.
 
 Major bumps (e.g., `1.x.x` → `2.0.0`) are NOT auto-deployed — the `ImagePolicy` range must be widened by hand.
-
-Until image automation is bootstrapped, image bumps are entirely manual: edit the `image:` lines in `deployment.yaml` and `cronjob-import.yaml`, commit, and let Flux roll out.
 
 ## Data refresh
 

--- a/apps/production/geohazardwatch/kustomization.yaml
+++ b/apps/production/geohazardwatch/kustomization.yaml
@@ -9,9 +9,8 @@ resources:
   - ingress.yaml
   - certificate.yaml
   - cronjob-import.yaml
-  # image-policy.yaml is intentionally NOT in this list yet.
-  # The production cluster's Flux is bootstrapped without
-  # image-reflector-controller / image-automation-controller, so the
-  # ImageRepository / ImagePolicy / ImageUpdateAutomation CRDs do not
-  # exist. Bootstrap those controllers first (see README), then add
-  # `- image-policy.yaml` here to enable auto-updates.
+
+# Image automation (ImageRepository / ImagePolicy / ImageUpdateAutomation)
+# lives in apps/production/image-automation/ — those resources are in the
+# flux-system namespace and would be rewritten to `geohazardwatch` if listed
+# here (the top-level `namespace:` above overrides per-resource values).

--- a/apps/production/image-automation/geohazardwatch-ghcr.sops.yaml
+++ b/apps/production/image-automation/geohazardwatch-ghcr.sops.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: ghcr-geohazardwatch
+    namespace: flux-system
+type: kubernetes.io/dockerconfigjson
+data:
+    .dockerconfigjson: ENC[AES256_GCM,data:lWFLG4E1LN8XnCJxC68RHJOVqEYNYbFw5lqfs1FMWnbN2eyD0pshMWcr2ubV+oBkRAGpeIdHKGuCaooe+dpMyxRbfQcfB+CiHcJKGI63bFgHntd6hFKNK89WxiGNpy0IhHh17r20AqJhWT9OtJobdxSg9PWHJyl9K3GVOOMp+/ZgGicPtCgz+g==,iv:0Lapt4+aPmoghY66qLwBbNvdSZLkazASLiMP8nycbHA=,tag:EcbB18nYOl7ug/UFyV5iXg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1sr8j9p87wuuqfnmharzqqnwj76yyc6mu5j3r5t7sr3j88wzn8exqwy6jhj
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEUThxY3l2SkRVWUhuQjRv
+            cUl4djVLOXl0R0dzQXQvWjh3MTdjdzJSWkFjCm1zYkprOGN5THVGeEFtd1pPbVZa
+            YjYrY2hDZzVEK0loREtLT0JOZ0hBS1UKLS0tIFNKbzFOTHU1eWlxcEFiR2dpN3k4
+            RGExdDdtc0F6SE9tQzZ2a2lNV1VxbTAKjCF5Fa8Reej8p23ImbYGj28r6gxzW8WL
+            L6BA0P3BOQ2nbfAuFFOLrk7Td3vrUW939UqYlYu4QPQjELF7D8Ukjg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-09T13:28:20Z"
+    mac: ENC[AES256_GCM,data:OaO4cnX2oaddhWE6hwhzQxUHyl2uPPqA3rhn0S1LOj3g6C7sxdUHlyRYpKvTLL71yv63MdFQeTUV2PJG/mWIL8bTzwNE5OzaX9VCeVT3KYbo0go92+ifXFXlB6GcwITYl3/YB/05Fq0iO2+/WJfA9i3puXPBKxp5A36B/eTtImU=,iv:FEdIM8Y/f8i1WZAHyH0eVbS/ortfXULt+EdA8CZHMzs=,tag:skObAcodntfP+yMgK1xRqQ==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.9.3

--- a/apps/production/image-automation/geohazardwatch-policy.yaml
+++ b/apps/production/image-automation/geohazardwatch-policy.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   image: ghcr.io/jwilleke/geohazardwatch
   interval: 10m
+  # GHCR package is private; without this secretRef the scan returns an empty
+  # tag list and ImagePolicy / ImageUpdateAutomation never advance the pin.
+  secretRef:
+    name: ghcr-geohazardwatch
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -44,5 +48,8 @@ spec:
     push:
       branch: master
   update:
+    # Setters scan deployment.yaml / cronjob-import.yaml in the geohazardwatch
+    # app dir for the `# {"$imagepolicy": "flux-system:geohazardwatch"}` marker
+    # — that path is unchanged even though this manifest now lives elsewhere.
     path: ./apps/production/geohazardwatch
     strategy: Setters

--- a/apps/production/image-automation/kustomization.yaml
+++ b/apps/production/image-automation/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No `namespace:` directive: every resource here lives in `flux-system`
+# (where image-reflector-controller / image-automation-controller look)
+# and declares its namespace explicitly.
+resources:
+  - geohazardwatch-policy.yaml
+  - geohazardwatch-ghcr.sops.yaml

--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -31,3 +31,8 @@ resources:
   - ./jimsmcp        # MCP server for custom infrastructure features
   - ./jimstest       # ngdpbase dev/test instance on jminm4
   - ./geohazardwatch # ngdpbase + ve-geology addon at geohazardwatch.com
+
+  # Cluster-level Flux image automation (ImageRepository / ImagePolicy /
+  # ImageUpdateAutomation, all in flux-system) for apps above that publish
+  # to private GHCR. Pull secrets are SOPS-encrypted alongside.
+  - ./image-automation


### PR DESCRIPTION
## Summary

- Moves the geohazardwatch image-automation manifests (`ImageRepository` + `ImagePolicy` + `ImageUpdateAutomation`) out of `apps/production/geohazardwatch/` into a new sibling `apps/production/image-automation/`. Required because the geohazardwatch kustomization sets `namespace: geohazardwatch`, which kustomize stamps onto every listed resource — that would rewrite the `flux-system`-scoped resources and image-reflector-controller would never see them.
- Adds `secretRef: { name: ghcr-geohazardwatch }` to the `ImageRepository`. The GHCR package is private; without a pull secret the scan returns empty and the auto-update loop never fires (root cause of #64).
- Drops the README's stale "controllers aren't installed yet, re-run `flux bootstrap`" section — both `image-reflector-controller` and `image-automation-controller` are already in `clusters/production/flux-system/gotk-components.yaml`.

## Why this is a draft

Two pieces still have to land on this branch before merge — once both are present, mark ready:

- [ ] Mint a GHCR PAT with `read:packages` scoped to `jwilleke/geohazardwatch`.
- [ ] Build the Secret manifest cleartext and SOPS-encrypt it in place:
  ```bash
  sops --encrypt --age age1sr8j9p87wuuqfnmharzqqnwj76yyc6mu5j3r5t7sr3j88wzn8exqwy6jhj \
    --encrypted-regex '^(data|stringData)$' \
    --in-place apps/production/image-automation/geohazardwatch-ghcr.sops.yaml
  ```
  Shape:
  ```yaml
  apiVersion: v1
  kind: Secret
  metadata:
    name: ghcr-geohazardwatch
    namespace: flux-system
  type: kubernetes.io/dockerconfigjson
  data:
    .dockerconfigjson: <base64-of-{"auths":{"ghcr.io":{"auth":"<base64 user:pat>"}}}>
  ```
- [ ] Append `- ./image-automation` to `apps/production/kustomization.yaml` (the activation flip).

The inner `apps/production/image-automation/kustomization.yaml` already lists `geohazardwatch-ghcr.sops.yaml` in its resources, so once you commit the encrypted file plus the parent-kustomization line, everything is wired.

**Do not merge before all three are in place** — otherwise the apps Flux Kustomization will fail to reconcile on the missing Secret file.

## Test plan

After the activating commit lands and Flux reconciles (~10 min):

- [ ] `flux -n flux-system get image repository geohazardwatch` shows `Ready: True` with `Last scan: <recent>` and a non-empty tag list (should include 1.2.0/1.2.1/1.2.2 per issue #64).
- [ ] `flux -n flux-system get image policy geohazardwatch` resolves to `1.2.2` (highest in `>=1.0.0 <2.0.0`).
- [ ] Within one `ImageUpdateAutomation` poll (~10 min), `git log master --author=fluxcdbot -1` shows a `chore(image-automation): bump geohazardwatch to ghcr.io/jwilleke/geohazardwatch:1.2.2` commit.
- [ ] `kubectl -n geohazardwatch get pods -l app=geohazardwatch -o jsonpath='{.items[*].spec.containers[*].image}'` reflects the new tag after rolling deploy.

## Rollback

Single `git revert` of the activation commit restores the prior state — image-automation directory is inert (not referenced by parent kustomization) until activated.

## Notes for reviewers

- The `ImageUpdateAutomation.spec.update.path` stays `./apps/production/geohazardwatch` even though this manifest now lives one directory over. Setters scan that path for `# {"$imagepolicy": ...}`-marked image lines in `deployment.yaml` / `cronjob-import.yaml`; the marker location hasn't moved.
- A similar gap likely exists for any other private-GHCR app (jimsmcp). The new `apps/production/image-automation/` is structured to host those (`jimsmcp-policy.yaml` + `jimsmcp-ghcr.sops.yaml`) without further layout changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)