### PR TITLE
fix(flux): re-enable SOPS decryption on the apps Kustomization

### DIFF
--- a/clusters/deby/apps.yaml
+++ b/clusters/deby/apps.yaml
@@ -16,3 +16,14 @@ spec:
   prune: true
   wait: true
   timeout: 5m0s
+  # Re-enabled after the legacy encrypted files (monitoring, transmission)
+  # were aligned to the same sops-age recipient as cloudflared and the
+  # ghcr-geohazardwatch pull secret introduced by #65 — see commit
+  # a736401 "fix(sops): align all encrypted files with the Flux sops-age
+  # recipient". Without this stanza, kustomize-controller passes the
+  # SOPS ciphertext through unmodified and reconciliation fails on
+  # any encrypted Secret under apps/production/.
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age


### PR DESCRIPTION
## Summary

Unsticks the apps Flux Kustomization, which has been failing reconcile since #65 merged with: \`Secret/flux-system/ghcr-geohazardwatch is SOPS encrypted, configuring decryption is required\`.

The \`decryption:\` block was originally added in #58, reverted in #59 because legacy encrypted files used a different age recipient. Today's \`a736401\` re-encrypted those files to the unified key, making it safe to re-enable.

Production apps remain running on the prior-good SHA (\`bc5ab434\`) while the apps Kustomization is stuck — nothing is currently down. Merging this lets the cluster reconcile to current master.

## Test plan

- [ ] Merge.
- [ ] Within ~1 min, \`flux get kustomization apps\` shows \`Ready: True\` at the new revision.
- [ ] \`kubectl -n flux-system get secret ghcr-geohazardwatch\` returns the decrypted Secret.
- [ ] \`kubectl -n flux-system get imagerepository,imagepolicy,imageupdateautomation geohazardwatch\` shows the resources applied (will sit inert until image controllers are installed — separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)