### PR TITLE
feat(yourphr): give the app the relay shared secret (yourphr#51)

### DIFF
--- a/apps/production/yourphr/deployment.yaml
+++ b/apps/production/yourphr/deployment.yaml
@@ -26,6 +26,17 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          env:
+            # Shared secret for polling the SMART OAuth relay's /pending (yourphr#50/#51).
+            # Same value as the relay's own secret (../yourphr-relay/relay-secret.sops.yaml).
+            # optional: the app starts without it; the relay-connect path just returns
+            # "relay not configured" until it's present.
+            - name: YOURPHR_RELAY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: yourphr-relay
+                  key: YOURPHR_RELAY_SECRET
+                  optional: true
           volumeMounts:
             - name: yourphr-data
               mountPath: /opt/fasten/db


### PR DESCRIPTION
Wires `YOURPHR_RELAY_SECRET` into the YourPHR **app** Deployment so the backend can authenticate to the relay's `/pending` endpoint.

## Why
The backend relay-poll connect path ([yourphr#73](https://github.com/jwilleke/yourphr/pull/73)) reads `YOURPHR_RELAY_SECRET` from the environment to poll the relay (#50) for the authorization code. The app Deployment didn't set it, so that path would fail in-cluster with "relay not configured".

## What
- Add an `env` entry to the `yourphr` container sourcing `YOURPHR_RELAY_SECRET` from the existing `yourphr-relay` Secret (same `yourphr` namespace, created in mj-infra-flux#105) via `secretKeyRef`.
- **`optional: true`** — the app still starts if the secret is absent, and the backend returns "relay not configured" instead of crashing. So this can't break the running app.
- `YOURPHR_RELAY_URL` left unset; the backend defaults to `https://relay.nerdsbythehour.com`.

After merge, Flux rolls the Deployment with the env var set, and the relay-connect flow works end-to-end in the cluster (pending the frontend wiring, yourphr#52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)