### PR TITLE
feat(yourphr-relay): Flux image-automation for the relay (yourphr#50)

### DIFF
--- a/apps/production/image-automation/kustomization.yaml
+++ b/apps/production/image-automation/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 # and declares its namespace explicitly.
 resources:
   - yourphr-policy.yaml
+  - yourphr-relay-policy.yaml
   - geohazardwatch-policy.yaml
   - owntracks-policy.yaml
   # geohazardwatch-ghcr.sops.yaml removed 2026-05-16 — ghcr package made

--- a/apps/production/image-automation/yourphr-relay-policy.yaml
+++ b/apps/production/image-automation/yourphr-relay-policy.yaml
@@ -1,0 +1,55 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: yourphr-relay
+  namespace: flux-system
+spec:
+  image: ghcr.io/jwilleke/yourphr-relay
+  interval: 5m
+  # GHCR package must be PUBLIC for anonymous scanning (same as ghcr.io/jwilleke/yourphr).
+  # Tags: :main (mutable) and :main-<run_number> (immutable, numerically sorted) from
+  # docker-relay.yaml (yourphr#71).
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: yourphr-relay
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: yourphr-relay
+  filterTags:
+    # Matches main-<N> tags emitted by docker-relay.yaml; extract the build number for ordering.
+    pattern: '^main-(\d+)$'
+    extract: '$1'
+  policy:
+    numerical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: yourphr-relay
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  git:
+    checkout:
+      ref:
+        branch: master
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        chore(image-automation): bump yourphr-relay to {{range .Changed.Changes}}{{.NewValue}} {{end}}
+    push:
+      branch: master
+  update:
+    # Scans deployment.yaml in the relay dir for the
+    # `# {"$imagepolicy": "flux-system:yourphr-relay"}` setter marker.
+    path: ./apps/production/yourphr-relay
+    strategy: Setters

--- a/apps/production/yourphr-relay/deployment.yaml
+++ b/apps/production/yourphr-relay/deployment.yaml
@@ -19,9 +19,9 @@ spec:
         - name: relay
           # SMART on FHIR store-and-poll relay (EPIC #20, yourphr#50).
           # Image built by https://github.com/jwilleke/yourphr/actions/workflows/docker-relay.yaml (yourphr#71).
-          # Pinned to :main; imagePullPolicy Always picks up the latest main build on restart.
-          image: ghcr.io/jwilleke/yourphr-relay:main
-          imagePullPolicy: Always
+          # Flux image-automation bumps this to the latest main-<N> tag (see
+          # ../image-automation/yourphr-relay-policy.yaml); immutable tags, so no imagePullPolicy needed.
+          image: ghcr.io/jwilleke/yourphr-relay:main-2 # {"$imagepolicy": "flux-system:yourphr-relay"}
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
Closes the gap found while testing: the relay Deployment was pinned to the mutable `:main` tag with **no image-automation**, so relay rebuilds (e.g. [yourphr#72](https://github.com/jwilleke/yourphr/pull/72)'s root handler) never rolled — the live pod stayed on the stale pre-#72 image (that's why `GET /` still 404s).

## What
Mirrors the main-app image-automation:
- New `apps/production/image-automation/yourphr-relay-policy.yaml`: `ImageRepository` + `ImagePolicy` (filter `^main-(\d+)$`, numerical asc) + `ImageUpdateAutomation` (scans `./apps/production/yourphr-relay`, Setters strategy) for `ghcr.io/jwilleke/yourphr-relay`.
- Relay `deployment.yaml`: image → immutable `:main-2` with the `# {"$imagepolicy": "flux-system:yourphr-relay"}` setter marker; dropped `imagePullPolicy: Always` (unneeded with immutable tags).

## Effect
- Pinning to **`main-2`** (the #72 root-handler build) rolls the live pod off the stale image → `GET /` returns the friendly page after reconcile.
- Future relay builds auto-bump like the app (fluxcdbot commits `chore(image-automation): bump yourphr-relay to main-<N>`).

## Prereq
The `ghcr.io/jwilleke/yourphr-relay` package must be **public** for anonymous Flux scanning (same as `ghcr.io/jwilleke/yourphr`). If it isn't yet: GitHub → jwilleke → Packages → yourphr-relay → make public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)