### PR TITLE
feat(monitoring): scrape + alert on YourPHR relay code arrivals (yourphr#50)

### DIFF
--- a/apps/production/monitoring/prometheus/config/alerting-rules.yourphr-relay.yaml
+++ b/apps/production/monitoring/prometheus/config/alerting-rules.yourphr-relay.yaml
@@ -1,0 +1,47 @@
+groups:
+  - name: yourphr-relay
+    interval: 30s
+    rules:
+      # A SMART authorization code arrived at the relay /callback ("a secret arrived").
+      # This is an informational event notification, not a fault: it fires when the
+      # callbacks counter increases, then resolves. Use it to confirm a provider login
+      # round-trip happened. The code itself is never exposed — only the count.
+      - alert: YourPHRRelayCodeReceived
+        expr: increase(yourphr_relay_callbacks_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: info
+          source: yourphr-relay
+        annotations:
+          summary: "YourPHR relay received {{ $value | printf \"%.0f\" }} authorization code(s)"
+          description: |
+            The SMART OAuth relay stored {{ $value | printf "%.0f" }} authorization code(s) at
+            /callback in the last 5m — a provider login round-trip reached the relay. Informational.
+
+      # Someone is polling /pending with a missing/wrong shared secret — possible probing.
+      - alert: YourPHRRelayUnauthorizedPolls
+        expr: increase(yourphr_relay_pending_total{result="unauthorized"}[5m]) > 5
+        for: 0m
+        labels:
+          severity: warning
+          source: yourphr-relay
+        annotations:
+          summary: "YourPHR relay: {{ $value | printf \"%.0f\" }} unauthorized /pending polls in 5m"
+          description: |
+            More than 5 /pending requests with a missing/invalid X-Yourphr-Token in 5m.
+            Likely a misconfigured client or someone probing the relay.
+
+      # Relay metrics endpoint unreachable — the relay may be down or not serving :9090.
+      - alert: YourPHRRelayScrapeDown
+        expr: up{job="yourphr-relay"} == 0
+        for: 10m
+        labels:
+          severity: warning
+          source: yourphr-relay
+        annotations:
+          summary: "YourPHR relay metrics scrape is down"
+          description: |
+            Prometheus cannot reach the relay /metrics at
+            yourphr-relay.yourphr.svc.cluster.local:9090. The relay pod may be down, or
+            running an image without the metrics server (requires yourphr#77).
+            Check: kubectl -n yourphr get pods -l app=yourphr-relay

--- a/apps/production/monitoring/prometheus/config/scrape-configs.yourphr-relay.yaml
+++ b/apps/production/monitoring/prometheus/config/scrape-configs.yourphr-relay.yaml
@@ -1,0 +1,13 @@
+scrape_configs:
+  # YourPHR SMART OAuth relay metrics (yourphr#50). The relay serves Prometheus text
+  # on its in-cluster-only metrics port 9090 (NOT the public :8080 tunnel path).
+  # Endpoint: http://yourphr-relay.yourphr.svc.cluster.local:9090/metrics
+  - job_name: "yourphr-relay"
+    static_configs:
+      - targets: ["yourphr-relay.yourphr.svc.cluster.local:9090"]
+    metrics_path: /metrics
+    scrape_interval: 30s
+    scrape_timeout: 10s
+    relabel_configs:
+      - target_label: source
+        replacement: yourphr-relay

--- a/apps/production/monitoring/prometheus/kustomization.yaml
+++ b/apps/production/monitoring/prometheus/kustomization.yaml
@@ -34,6 +34,9 @@ configMapGenerator:
       # NetAlertX /metrics scrape + alert rules (deby#27)
       - config/scrape-configs.netalertx.yaml
       - config/alerting-rules.netalertx.yaml
+      # YourPHR SMART relay /metrics scrape + alert rules (yourphr#50)
+      - config/scrape-configs.yourphr-relay.yaml
+      - config/alerting-rules.yourphr-relay.yaml
       # coinpoet and tayle configs removed
 
 labels:

--- a/apps/production/yourphr-relay/deployment.yaml
+++ b/apps/production/yourphr-relay/deployment.yaml
@@ -25,6 +25,8 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+            - containerPort: 9090
+              name: metrics # in-cluster Prometheus scrape only; NOT routed via the public tunnel
           envFrom:
             # YOURPHR_RELAY_SECRET — gates /pending. See relay-secret.sops.yaml.example.
             - secretRef:

--- a/apps/production/yourphr-relay/service.yaml
+++ b/apps/production/yourphr-relay/service.yaml
@@ -10,3 +10,6 @@ spec:
     - name: http
       port: 8080
       targetPort: 8080
+    - name: metrics
+      port: 9090
+      targetPort: 9090


### PR DESCRIPTION
The **"alert when a secret arrives"** follow-up to [yourphr#77](https://github.com/jwilleke/yourphr/pull/77) (which added the relay metrics). Wires the relay's in-cluster metrics into the existing raw-Prometheus + Alertmanager stack.

## What
- **Relay Deployment/Service**: expose metrics port **9090** (in-cluster only — the public Cloudflare tunnel still routes only `:8080`, so metrics aren't internet-exposed).
- **`scrape-configs.yourphr-relay.yaml`**: Prometheus job scraping `yourphr-relay.yourphr.svc.cluster.local:9090/metrics` every 30s.
- **`alerting-rules.yourphr-relay.yaml`**:
  - **`YourPHRRelayCodeReceived`** (info) — fires when `yourphr_relay_callbacks_total` increases, i.e. **a SMART auth code arrived at `/callback`**. The alert carries the *count* only, never the code.
  - **`YourPHRRelayUnauthorizedPolls`** (warning) — >5 bad-secret `/pending` polls in 5m (probing signal).
  - **`YourPHRRelayScrapeDown`** (warning) — relay `/metrics` unreachable.
- Registered both files in the prometheus `configMapGenerator`.

Routes via the existing Alertmanager (→ Slack/email).

## Merge ordering
Scraping returns data only once a relay image **with the metrics server** is deployed — that needs [yourphr#77](https://github.com/jwilleke/yourphr/pull/77) merged + the relay image rolled (image-automation from #107). **Merge this after #77 has deployed** to avoid a transient `YourPHRRelayScrapeDown`. (`YourPHRRelayScrapeDown` has a 10m `for:` to soften that.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)