### PR TITLE
fix(yourphr): poll relay over in-cluster Service, not public URL (yourphr#51)

### DIFF
--- a/apps/production/yourphr/deployment.yaml
+++ b/apps/production/yourphr/deployment.yaml
@@ -27,6 +27,13 @@ spec:
             - containerPort: 8080
               name: http
           env:
+            # Poll the relay over the in-cluster Service, NOT its public Cloudflare URL.
+            # The backend runs inside the cluster; hitting https://relay.nerdsbythehour.com
+            # from here hairpins out to Cloudflare and back through the tunnel and times out
+            # (observed: "Get https://relay.nerdsbythehour.com/pending …: context deadline
+            # exceeded"). The in-cluster Service reaches the same relay pod directly. (yourphr#51)
+            - name: YOURPHR_RELAY_URL
+              value: "http://yourphr-relay.yourphr.svc.cluster.local:8080"
             # Shared secret for polling the SMART OAuth relay's /pending (yourphr#50/#51).
             # Same value as the relay's own secret (../yourphr-relay/relay-secret.sops.yaml).
             # optional: the app starts without it; the relay-connect path just returns


### PR DESCRIPTION
**Root cause of "code stored but never delivered."** The backend's relay poll was hitting the relay's **public** Cloudflare URL (`https://relay.nerdsbythehour.com/pending`), but the app runs **inside the cluster** — so that call hairpins out to Cloudflare and back through the tunnel and **hangs/times out**. From the app logs:

```
relay: request failed: Get "https://relay.nerdsbythehour.com/pending?state=…": context deadline exceeded
relay: timed out waiting for authorization code: context deadline exceeded
POST /api/secure/source/connect 502 (30005ms)
```

So a successful OAuth login's code reached the relay's `/callback` (public — fine), but the backend could never fetch it from `/pending` → every connect 502'd, even when auth succeeded.

## Fix
Set `YOURPHR_RELAY_URL` on the app to the **cluster-internal Service** so the backend reaches the same relay pod directly:
```
YOURPHR_RELAY_URL=http://yourphr-relay.yourphr.svc.cluster.local:8080
```
(The relay client reads `YOURPHR_RELAY_URL`; default was the public URL. The provider `redirect_uri` stays the public `/callback` — only the backend's *poll* moves in-cluster.)

After this rolls, a successful login should show `relay: delivered authorization code …` in the relay logs and the connect should complete.

Refs yourphr#51, yourphr#53
🤖 Generated with [Claude Code](https://claude.com/claude-code)