### PR TITLE
perf(flux): shorten yourphr image scan + automation interval 5m → 1m

### DIFF
--- a/apps/production/image-automation/yourphr-policy.yaml
+++ b/apps/production/image-automation/yourphr-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/jwilleke/yourphr
-  interval: 5m
+  interval: 1m   # scan ghcr frequently so a new build deploys soon after push (was 5m)
   # GHCR package must be PUBLIC for anonymous scanning.
   # To make it public: GitHub → jwilleke/yourphr → Packages → yourphr → Package settings → Change visibility → Public
   # Tags: :main (mutable, always latest) and :main-<run_number> (immutable, numerically sorted).
@@ -35,7 +35,7 @@ metadata:
   name: yourphr
   namespace: flux-system
 spec:
-  interval: 5m
+  interval: 1m   # reconcile the deployment.yaml image bump promptly after a new tag is found (was 5m)
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/apps/production/image-automation/yourphr-relay-policy.yaml
+++ b/apps/production/image-automation/yourphr-relay-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/jwilleke/yourphr-relay
-  interval: 5m
+  interval: 1m   # scan ghcr frequently for new relay builds (was 5m)
   # GHCR package must be PUBLIC for anonymous scanning (same as ghcr.io/jwilleke/yourphr).
   # Tags: :main (mutable) and :main-<run_number> (immutable, numerically sorted) from
   # docker-relay.yaml (yourphr#71).
@@ -32,7 +32,7 @@ metadata:
   name: yourphr-relay
   namespace: flux-system
 spec:
-  interval: 5m
+  interval: 1m   # reconcile the relay image bump promptly (was 5m)
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
Tightens the GitOps **pushed → live** lag for the yourphr app + relay.

The `ImageRepository` scan (notices a new ghcr tag) and the `ImageUpdateAutomation` reconcile (commits the `deployment.yaml` image bump) were both **5m**, so a fresh build could wait up to ~10m before rolling. **1m each → ~1-2m.**

- `apps/production/image-automation/yourphr-policy.yaml` — both intervals 5m → 1m
- `apps/production/image-automation/yourphr-relay-policy.yaml` — both intervals 5m → 1m

GHCR scanning every 1m is cheap (public registry). **Tag scheme unchanged** — `ImagePolicy` still selects `main-<N>` numerically (jwilleke/yourphr#1). Switching to track semver release tags (jwilleke/yourphr#91) would be a separate, deliberate change (deploys per-release, not per-push).

Pairs with jwilleke/yourphr#121 (removed the 20-min test-suite from the image build), so the full merge→live cycle drops from ~10+ min toward a few minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)