### PR TITLE
feat(yourphr): public ingress for favicon + PWA manifest assets

### DIFF
--- a/apps/production/yourphr/kustomization.yaml
+++ b/apps/production/yourphr/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./service.yaml
   - ./authentik-middleware.yaml
   - ./ingress.yaml
+  - ./public-assets-ingress.yaml
   - ./backup-cronjob.yaml
 
 labels:

--- a/apps/production/yourphr/public-assets-ingress.yaml
+++ b/apps/production/yourphr/public-assets-ingress.yaml
@@ -1,0 +1,41 @@
+# Public (no forward-auth) ingress for static branding assets ONLY:
+# the PWA web app manifest + favicons under /web/assets/favicon/.
+#
+# Why: browsers fetch rel="manifest" (and favicons) WITHOUT credentials, so the
+# authentik-forwardauth middleware on the main ingress 302's them to the auth server;
+# the browser then refuses to use the auth login page as a manifest (and YourPHR's
+# own manifest-src 'self' CSP blocks the cross-origin result). These are non-sensitive
+# static branding files, so route them straight to the app, bypassing forward-auth.
+#
+# Scope is deliberately narrow: only /web/assets/favicon/. All app code, data, and
+# PHI stay behind auth -- the app's own JWT guards /api/secure, and the rest of the
+# site keeps the forward-auth middleware via yourphr-ingress.
+#
+# Traefik picks this router over the catch-all "/" router for matching requests
+# because its PathPrefix rule is longer (higher auto-priority). There is intentionally
+# NO authentik-forwardauth middleware annotation here.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: yourphr-public-assets
+  namespace: yourphr
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - yourphr.nerdsbythehour.com
+      secretName: yourphr-nerdsbythehour-com-tls
+  rules:
+    - host: yourphr.nerdsbythehour.com
+      http:
+        paths:
+          - path: /web/assets/favicon
+            pathType: Prefix
+            backend:
+              service:
+                name: yourphr
+                port:
+                  number: 8080


### PR DESCRIPTION
## What

Adds a second, narrowly-scoped Traefik `Ingress` (`yourphr-public-assets`) for `/web/assets/favicon/` on `yourphr.nerdsbythehour.com` with **no authentik-forwardauth middleware**.

## Why

Browsers fetch the PWA web app manifest (`rel="manifest"`) and favicons **without credentials**. The forward-auth middleware on `yourphr-ingress` therefore 302's those requests to Authentik, and:
- the browser refuses to use the auth login page as a manifest, and
- YourPHR's `manifest-src 'self'` CSP (shipped in jwilleke/yourphr#124) blocks the cross-origin result.

Result today: a console CSP error on every load and a non-functional PWA manifest. This routes those non-sensitive static branding files straight to the app.

## Security scope

- **Narrow:** only `/web/assets/favicon/` (favicons, `site.webmanifest`, `browserconfig.xml`). No app code, data, or PHI.
- App PHI stays behind the **app's own JWT** on `/api/secure`; every other path keeps forward-auth via `yourphr-ingress`.
- Traefik selects this router over the catch-all `/` router for matching requests because its `PathPrefix` rule is longer (higher auto-priority).

## Isolation note

YourPHR is kept **agnostic to Authentik/Traefik/Flux** — the app-side fix (manifest icon paths made base-href-relative) landed in the YourPHR repo as a general correctness fix; this Authentik-specific concern lives entirely here in infra.

## Companion

- App-side fix: jwilleke/yourphr#126 (commit `1621a0d7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)