### PR TITLE
feat(yourphr): deploy yourphr-cda-converter sidecar + enable C-CDA import

### DIFF
--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
   # Protected Applications
   - ./yourphr            # Personal health record aggregator; authentik forward-auth, internal-only (mj-infra-flux#103)
   - ./yourphr-relay      # SMART OAuth relay; public via Cloudflare Tunnel (yourphr#50, mj-infra-flux#104+#105)
+  - ./yourphr-cda-converter  # C-CDA/CCD import sidecar; internal-only, no Ingress (mj-infra-flux#114, yourphr#254)
   - ./traefik-dashboard  # Traefik dashboard at traefik.nerdsbythehour.com; authentik forward-auth (mj-infra-flux#89)
   - ./teslamate
   - ./home-assistant-proxy

--- a/apps/production/yourphr-cda-converter/deployment.yaml
+++ b/apps/production/yourphr-cda-converter/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yourphr-cda-converter
+  namespace: yourphr
+  labels:
+    app: yourphr-cda-converter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: yourphr-cda-converter
+  template:
+    metadata:
+      labels:
+        app: yourphr-cda-converter
+    spec:
+      containers:
+        - name: cda-converter
+          # Metriport AGPL-3.0 fhir-converter, repackaged for YourPHR (yourphr#254, mj-infra-flux#114).
+          # Built by https://github.com/jwilleke/yourphr/actions/workflows/docker-cda-converter.yaml.
+          # Image is public (ghcr.io/jwilleke); no imagePullSecret needed.
+          # Pinned to immutable SHA; no Flux image-automation (no numerical tag scheme).
+          image: ghcr.io/jwilleke/yourphr-cda-converter:c6751a33ac5dc7aae18a041dca42e14a5a482111
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi

--- a/apps/production/yourphr-cda-converter/kustomization.yaml
+++ b/apps/production/yourphr-cda-converter/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# C-CDA / CCD converter sidecar for YourPHR (mj-infra-flux#114, yourphr#254).
+# Deploys into the `yourphr` namespace (owned by ../yourphr/namespace.yaml — not redeclared here).
+# INTERNAL-ONLY: no Ingress — raw C-CDA documents are full PHI; must never leave the cluster.
+resources:
+  - ./deployment.yaml
+  - ./service.yaml
+
+labels:
+  - pairs:
+      app.jimwilleke.com/name: yourphr-cda-converter

--- a/apps/production/yourphr-cda-converter/service.yaml
+++ b/apps/production/yourphr-cda-converter/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: yourphr-cda-converter
+  namespace: yourphr
+spec:
+  selector:
+    app: yourphr-cda-converter
+  ports:
+    - port: 8080
+      targetPort: 8080
+# INTERNAL-ONLY: intentionally no Ingress — raw C-CDA is full PHI; cluster-internal access only.

--- a/apps/production/yourphr/deployment.yaml
+++ b/apps/production/yourphr/deployment.yaml
@@ -44,6 +44,12 @@ spec:
                   name: yourphr-relay
                   key: YOURPHR_RELAY_SECRET
                   optional: true
+            # C-CDA / CCD converter sidecar (mj-infra-flux#114, yourphr#254).
+            # Reaches the converter in-cluster; same namespace so short DNS resolves.
+            - name: FASTEN_CDA_CONVERTER_ENABLED
+              value: "true"
+            - name: FASTEN_CDA_CONVERTER_URL
+              value: "http://yourphr-cda-converter.yourphr.svc.cluster.local:8080"
           volumeMounts:
             - name: yourphr-data
               mountPath: /opt/fasten/db


### PR DESCRIPTION
## Summary

- Add `apps/production/yourphr-cda-converter/` — Deployment + Service in the `yourphr` namespace, no Ingress (raw C-CDA is full PHI, must stay cluster-internal). Wired into the parent kustomization alongside `yourphr-relay`.
- Enable on the `yourphr` Deployment via two env vars: `FASTEN_CDA_CONVERTER_ENABLED=true` and `FASTEN_CDA_CONVERTER_URL=http://yourphr-cda-converter.yourphr.svc.cluster.local:8080`.
- Image `ghcr.io/jwilleke/yourphr-cda-converter:c6751a33…` is public; no `imagePullSecret` needed. Pinned to the immutable SHA tag; no Flux image-automation.

**Namespace note:** the example manifest in `jwilleke/yourphr` uses `namespace: fasten` (upstream Fasten default). This cluster runs everything under `namespace: yourphr` — corrected throughout.

## Test plan

- [ ] `kubectl -n yourphr get pods` — `yourphr-cda-converter` Running + `yourphr` rolled with new env vars
- [ ] Upload a `.xml`/`.ccd` in the app and confirm it imports without error
- [ ] Re-upload the same file — confirm no duplicate records

Closes #114. Completes the infra half of jwilleke/yourphr#254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)