### PR TITLE
fix(prometheus): relabel kube-state-metrics job so KSM dashboards work

### DIFF
--- a/apps/production/monitoring/prometheus/config/prometheus.yaml
+++ b/apps/production/monitoring/prometheus/config/prometheus.yaml
@@ -260,3 +260,9 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_service_name]
         action: replace
         target_label: service
+      # kube-state-metrics is scraped by this generic job but dashboards (e.g. garysdevil/kube-state-metrics-v2)
+      # filter on job="kube-state-metrics". Override the job label for that service only.
+      - source_labels: [__meta_kubernetes_service_name]
+        regex: kube-state-metrics
+        target_label: job
+        replacement: kube-state-metrics


### PR DESCRIPTION
## Summary

- KSM pod is running and being scraped, but via the generic `kubernetes-service-endpoints` job — all its metrics carry `job="kubernetes-service-endpoints"`
- Community dashboards (garysdevil/kube-state-metrics-v2, etc.) filter on `job="kube-state-metrics"` → no data
- Fix: one `relabel_config` rule in the `kubernetes-service-endpoints` job that overrides `job → kube-state-metrics` when `__meta_kubernetes_service_name` matches `kube-state-metrics`
- No duplicate scrape, no annotation change, no new scrape job needed

## Test plan

- [ ] Merge + Flux reconciles Prometheus ConfigMap
- [ ] Prometheus reloads config (check `/-/reload` or restart)
- [ ] Verify in Prometheus UI: `kube_pod_info` now has `job="kube-state-metrics"` targets
- [ ] Grafana garysdevil-kube-state-metrics-v2 dashboard shows data

🤖 Generated with [Claude Code](https://claude.com/claude-code)