### PR TITLE
fix(yourphr): rename FASTEN_CDA_CONVERTER_* env vars to YOURPHR_* prefix

### DIFF
--- a/apps/production/yourphr/deployment.yaml
+++ b/apps/production/yourphr/deployment.yaml
@@ -46,9 +46,9 @@ spec:
                   optional: true
             # C-CDA / CCD converter sidecar (mj-infra-flux#114, yourphr#254).
             # Reaches the converter in-cluster; same namespace so short DNS resolves.
-            - name: FASTEN_CDA_CONVERTER_ENABLED
+            - name: YOURPHR_CDA_CONVERTER_ENABLED
               value: "true"
-            - name: FASTEN_CDA_CONVERTER_URL
+            - name: YOURPHR_CDA_CONVERTER_URL
               value: "http://yourphr-cda-converter.yourphr.svc.cluster.local:8080"
           volumeMounts:
             - name: yourphr-data


### PR DESCRIPTION
Closes #117.

## What

Rename the two `FASTEN_CDA_CONVERTER_*` env vars in the yourphr Deployment to the `YOURPHR_*` prefix:

- `FASTEN_CDA_CONVERTER_ENABLED` → `YOURPHR_CDA_CONVERTER_ENABLED`
- `FASTEN_CDA_CONVERTER_URL` → `YOURPHR_CDA_CONVERTER_URL`

## Why

The app is switching its viper env prefix from `FASTEN_` to `YOURPHR_` (jwilleke/yourphr#273). The shim that mirrored `FASTEN_*` → `YOURPHR_*` at startup kept things working, but left deprecation warnings in logs. This removes the deprecated names.

## Audit

Only these two vars used the old prefix — all other env vars (`YOURPHR_RELAY_URL`, `YOURPHR_RELAY_SECRET`) already used `YOURPHR_*`. The configmap filesystem paths (`/opt/fasten/db/fasten.db`) are container-internal paths, not env vars, and are unchanged.

## Test plan

- [ ] Merge + Flux rolls the yourphr pod
- [ ] Pod starts clean — no `[deprecation] FASTEN_…` warnings in logs
- [ ] C-CDA converter feature still works (cda-converter pod reachable)
- [ ] Ping jwilleke/yourphr#273 to remove the compatibility shim from the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)