### PR TITLE
fix(grafana): correct Failed Pods query in NOC dashboard

### DIFF
--- a/apps/production/monitoring/grafana/config/dashboards/env-health-noc.json
+++ b/apps/production/monitoring/grafana/config/dashboards/env-health-noc.json
@@ -192,7 +192,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "count(kube_pod_status_phase{phase=\"Failed\"}) or vector(0)",
+          "expr": "count(kube_pod_status_phase{phase=\"Failed\"} == 1) or vector(0)",
           "instant": true,
           "legendFormat": "failed",
           "refId": "A"


### PR DESCRIPTION
Missing `== 1` filter — KSM emits all phase labels per pod so `count(kube_pod_status_phase{phase="Failed"})` hit every pod. Fix: `== 1` to count only pods actually in Failed state. Showed 51 instead of 0.