### PR TITLE
feat(grafana): add dataLinks to all NOC dashboard panels

### DIFF
--- a/apps/production/monitoring/grafana/config/dashboards/env-health-noc.json
+++ b/apps/production/monitoring/grafana/config/dashboards/env-health-noc.json
@@ -9,7 +9,7 @@
   "title": "Environment Health",
   "uid": "env-health-noc",
   "schemaVersion": 39,
-  "version": 1,
+  "version": 2,
   "refresh": "30s",
   "time": { "from": "now-5m", "to": "now" },
   "timepicker": {},
@@ -53,7 +53,10 @@
             ]
           },
           "unit": "short",
-          "noValue": "0"
+          "noValue": "0",
+          "links": [
+            { "title": "Grafana alert list", "url": "https://grafana.nerdsbythehour.com/alerting/list", "targetBlank": true }
+          ]
         },
         "overrides": []
       },
@@ -74,6 +77,9 @@
       "id": 2,
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "h": 6, "w": 21, "x": 3, "y": 0 },
+      "links": [
+        { "title": "Prometheus alerts", "url": "https://prometheus.nerdsbythehour.com/alerts", "targetBlank": true }
+      ],
       "options": {
         "showHeader": true,
         "cellHeight": "sm",
@@ -87,19 +93,16 @@
           {
             "matcher": { "id": "byName", "options": "severity" },
             "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": { "type": "color-text" }
-              },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
               {
                 "id": "mappings",
                 "value": [
                   {
                     "type": "value",
                     "options": {
-                      "critical": { "color": "red", "index": 0, "text": "critical" },
+                      "critical": { "color": "red",    "index": 0, "text": "critical" },
                       "warning":  { "color": "yellow", "index": 1, "text": "warning" },
-                      "info":     { "color": "blue", "index": 2, "text": "info" }
+                      "info":     { "color": "blue",   "index": 2, "text": "info" }
                     }
                   }
                 ]
@@ -113,30 +116,13 @@
           "id": "organize",
           "options": {
             "excludeByName": {
-              "Time": true,
-              "Value": true,
-              "__name__": true,
-              "alertstate": true,
-              "app": true,
-              "app_jimwilleke_com_name": true,
-              "controller_revision_hash": true,
-              "endpoint": true,
-              "instance": true,
-              "job": true,
-              "kubernetes_namespace": true,
-              "kustomize_toolkit_fluxcd_io_name": true,
-              "kustomize_toolkit_fluxcd_io_namespace": true,
-              "pod_template_generation": true,
-              "service": true
+              "Time": true, "Value": true, "__name__": true, "alertstate": true,
+              "app": true, "app_jimwilleke_com_name": true, "controller_revision_hash": true,
+              "endpoint": true, "instance": true, "job": true, "kubernetes_namespace": true,
+              "kustomize_toolkit_fluxcd_io_name": true, "kustomize_toolkit_fluxcd_io_namespace": true,
+              "pod_template_generation": true, "service": true
             },
-            "indexByName": {
-              "alertname": 0,
-              "severity": 1,
-              "namespace": 2,
-              "pod": 3,
-              "summary": 4,
-              "description": 5
-            },
+            "indexByName": { "alertname": 0, "severity": 1, "namespace": 2, "pod": 3, "summary": 4, "description": 5 },
             "renameByName": {}
           }
         }
@@ -169,23 +155,14 @@
       "gridPos": { "h": 4, "w": 4, "x": 0, "y": 7 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
-            ]
-          },
-          "unit": "short",
-          "noValue": "0"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] },
+          "unit": "short", "noValue": "0",
+          "links": [ { "title": "KSM dashboard", "url": "https://grafana.nerdsbythehour.com/d/garysdevil-kube-state-metrics-v2", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -193,9 +170,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "count(kube_pod_status_phase{phase=\"Failed\"} == 1) or vector(0)",
-          "instant": true,
-          "legendFormat": "failed",
-          "refId": "A"
+          "instant": true, "legendFormat": "failed", "refId": "A"
         }
       ]
     },
@@ -207,31 +182,15 @@
       "gridPos": { "h": 4, "w": 4, "x": 4, "y": 7 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
-            ]
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "NOT READY", "color": "red", "index": 0 },
-                "1": { "text": "READY", "color": "green", "index": 1 }
-              }
-            }
-          ],
-          "unit": "short"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "mappings": [ { "type": "value", "options": { "0": { "text": "NOT READY", "color": "red", "index": 0 }, "1": { "text": "READY", "color": "green", "index": 1 } } } ],
+          "unit": "short",
+          "links": [ { "title": "Prometheus targets", "url": "https://prometheus.nerdsbythehour.com/targets", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -239,9 +198,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "min(kube_node_status_condition{condition=\"Ready\",status=\"true\"})",
-          "instant": true,
-          "legendFormat": "node",
-          "refId": "A"
+          "instant": true, "legendFormat": "node", "refId": "A"
         }
       ]
     },
@@ -253,31 +210,15 @@
       "gridPos": { "h": 4, "w": 4, "x": 8, "y": 7 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
-            ]
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "DOWN", "color": "red", "index": 0 },
-                "1": { "text": "UP", "color": "green", "index": 1 }
-              }
-            }
-          ],
-          "unit": "short"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "mappings": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 0 }, "1": { "text": "UP", "color": "green", "index": 1 } } } ],
+          "unit": "short",
+          "links": [ { "title": "Open yourphr", "url": "https://yourphr.nerdsbythehour.com", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -285,9 +226,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "kube_deployment_status_replicas_available{deployment=\"yourphr\",namespace=\"yourphr\"}",
-          "instant": true,
-          "legendFormat": "yourphr",
-          "refId": "A"
+          "instant": true, "legendFormat": "yourphr", "refId": "A"
         }
       ]
     },
@@ -299,31 +238,15 @@
       "gridPos": { "h": 4, "w": 4, "x": 12, "y": 7 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
-            ]
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "DOWN", "color": "red", "index": 0 },
-                "1": { "text": "UP", "color": "green", "index": 1 }
-              }
-            }
-          ],
-          "unit": "short"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "mappings": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 0 }, "1": { "text": "UP", "color": "green", "index": 1 } } } ],
+          "unit": "short",
+          "links": [ { "title": "Relay metrics", "url": "https://prometheus.nerdsbythehour.com/graph?g0.expr=up%7Bjob%3D%22yourphr-relay%22%7D", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -331,9 +254,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "up{job=\"yourphr-relay\"}",
-          "instant": true,
-          "legendFormat": "relay",
-          "refId": "A"
+          "instant": true, "legendFormat": "relay", "refId": "A"
         }
       ]
     },
@@ -346,24 +267,14 @@
       "gridPos": { "h": 4, "w": 4, "x": 16, "y": 7 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 5400 },
-              { "color": "red", "value": 7200 }
-            ]
-          },
-          "unit": "s",
-          "decimals": 0
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 5400 }, { "color": "red", "value": 7200 } ] },
+          "unit": "s", "decimals": 0,
+          "links": [ { "title": "deby host errors", "url": "https://grafana.nerdsbythehour.com/d/deby-host-errors", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -371,9 +282,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "time() - max(kube_job_status_completion_time{namespace=\"yourphr\"})",
-          "instant": true,
-          "legendFormat": "age",
-          "refId": "A"
+          "instant": true, "legendFormat": "age", "refId": "A"
         }
       ]
     },
@@ -394,31 +303,15 @@
       "gridPos": { "h": 4, "w": 4, "x": 0, "y": 12 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
-            ]
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "DEGRADED", "color": "red", "index": 0 },
-                "1": { "text": "ONLINE", "color": "green", "index": 1 }
-              }
-            }
-          ],
-          "unit": "short"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "mappings": [ { "type": "value", "options": { "0": { "text": "DEGRADED", "color": "red", "index": 0 }, "1": { "text": "ONLINE", "color": "green", "index": 1 } } } ],
+          "unit": "short",
+          "links": [ { "title": "deby host errors", "url": "https://grafana.nerdsbythehour.com/d/deby-host-errors", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -426,9 +319,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "min(deby_zfs_pool_healthy{pool=\"deby-backup\",job=\"kubernetes-service-endpoints\"})",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
+          "instant": true, "legendFormat": "", "refId": "A"
         }
       ]
     },
@@ -440,31 +331,15 @@
       "gridPos": { "h": 4, "w": 4, "x": 4, "y": 12 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
-            ]
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "DEGRADED", "color": "red", "index": 0 },
-                "1": { "text": "ONLINE", "color": "green", "index": 1 }
-              }
-            }
-          ],
-          "unit": "short"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "mappings": [ { "type": "value", "options": { "0": { "text": "DEGRADED", "color": "red", "index": 0 }, "1": { "text": "ONLINE", "color": "green", "index": 1 } } } ],
+          "unit": "short",
+          "links": [ { "title": "deby host errors", "url": "https://grafana.nerdsbythehour.com/d/deby-host-errors", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -472,9 +347,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "min(deby_zfs_pool_healthy{pool=\"nas-backup\",job=\"kubernetes-service-endpoints\"})",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
+          "instant": true, "legendFormat": "", "refId": "A"
         }
       ]
     },
@@ -487,24 +360,14 @@
       "gridPos": { "h": 4, "w": 4, "x": 8, "y": 12 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 70 },
-              { "color": "red", "value": 85 }
-            ]
-          },
-          "unit": "percent",
-          "decimals": 0
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 85 } ] },
+          "unit": "percent", "decimals": 0,
+          "links": [ { "title": "deby host errors", "url": "https://grafana.nerdsbythehour.com/d/deby-host-errors", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -512,9 +375,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "max(deby_zfs_pool_capacity_pct{job=\"kubernetes-service-endpoints\"})",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
+          "instant": true, "legendFormat": "", "refId": "A"
         }
       ]
     },
@@ -526,23 +387,14 @@
       "gridPos": { "h": 4, "w": 4, "x": 12, "y": 12 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
-            ]
-          },
-          "unit": "short",
-          "noValue": "0"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] },
+          "unit": "short", "noValue": "0",
+          "links": [ { "title": "deby host errors", "url": "https://grafana.nerdsbythehour.com/d/deby-host-errors", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -550,9 +402,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "count(node_systemd_unit_state{state=\"failed\",job=\"kubernetes-service-endpoints\"} == 1) or vector(0)",
-          "instant": true,
-          "legendFormat": "units",
-          "refId": "A"
+          "instant": true, "legendFormat": "units", "refId": "A"
         }
       ]
     },
@@ -564,24 +414,14 @@
       "gridPos": { "h": 4, "w": 4, "x": 16, "y": 12 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 80 },
-              { "color": "red", "value": 90 }
-            ]
-          },
-          "unit": "percent",
-          "decimals": 0
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 80 }, { "color": "red", "value": 90 } ] },
+          "unit": "percent", "decimals": 0,
+          "links": [ { "title": "deby host errors", "url": "https://grafana.nerdsbythehour.com/d/deby-host-errors", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -589,9 +429,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "(1 - avg(node_memory_MemAvailable_bytes{job=\"kubernetes-service-endpoints\"}) / avg(node_memory_MemTotal_bytes{job=\"kubernetes-service-endpoints\"})) * 100",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
+          "instant": true, "legendFormat": "", "refId": "A"
         }
       ]
     },
@@ -603,24 +441,14 @@
       "gridPos": { "h": 4, "w": 4, "x": 20, "y": 12 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 75 },
-              { "color": "red", "value": 90 }
-            ]
-          },
-          "unit": "percent",
-          "decimals": 0
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 75 }, { "color": "red", "value": 90 } ] },
+          "unit": "percent", "decimals": 0,
+          "links": [ { "title": "deby host errors", "url": "https://grafana.nerdsbythehour.com/d/deby-host-errors", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -628,9 +456,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "(1 - avg(node_filesystem_avail_bytes{mountpoint=\"/\",job=\"kubernetes-service-endpoints\"}) / avg(node_filesystem_size_bytes{mountpoint=\"/\",job=\"kubernetes-service-endpoints\"})) * 100",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
+          "instant": true, "legendFormat": "", "refId": "A"
         }
       ]
     },
@@ -651,31 +477,15 @@
       "gridPos": { "h": 3, "w": 4, "x": 0, "y": 17 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
-            ]
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "DOWN", "color": "red", "index": 0 },
-                "1": { "text": "UP", "color": "green", "index": 1 }
-              }
-            }
-          ],
-          "unit": "short"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "mappings": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 0 }, "1": { "text": "UP", "color": "green", "index": 1 } } } ],
+          "unit": "short",
+          "links": [ { "title": "Open", "url": "https://nerdsbythehour.com", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -683,9 +493,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "probe_success{instance=\"https://nerdsbythehour.com\"}",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
+          "instant": true, "legendFormat": "", "refId": "A"
         }
       ]
     },
@@ -697,31 +505,15 @@
       "gridPos": { "h": 3, "w": 4, "x": 4, "y": 17 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
-            ]
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "DOWN", "color": "red", "index": 0 },
-                "1": { "text": "UP", "color": "green", "index": 1 }
-              }
-            }
-          ],
-          "unit": "short"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "mappings": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 0 }, "1": { "text": "UP", "color": "green", "index": 1 } } } ],
+          "unit": "short",
+          "links": [ { "title": "Open", "url": "https://cdn.nerdsbythehour.com", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -729,9 +521,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "probe_success{instance=\"https://cdn.nerdsbythehour.com\"}",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
+          "instant": true, "legendFormat": "", "refId": "A"
         }
       ]
     },
@@ -743,31 +533,15 @@
       "gridPos": { "h": 3, "w": 4, "x": 8, "y": 17 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
-            ]
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "DOWN", "color": "red", "index": 0 },
-                "1": { "text": "UP", "color": "green", "index": 1 }
-              }
-            }
-          ],
-          "unit": "short"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "mappings": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 0 }, "1": { "text": "UP", "color": "green", "index": 1 } } } ],
+          "unit": "short",
+          "links": [ { "title": "Open", "url": "https://auth.nerdsbythehour.com", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -775,9 +549,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "probe_success{instance=\"https://auth.nerdsbythehour.com\"}",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
+          "instant": true, "legendFormat": "", "refId": "A"
         }
       ]
     },
@@ -789,31 +561,15 @@
       "gridPos": { "h": 3, "w": 4, "x": 12, "y": 17 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
-            ]
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "DOWN", "color": "red", "index": 0 },
-                "1": { "text": "UP", "color": "green", "index": 1 }
-              }
-            }
-          ],
-          "unit": "short"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "mappings": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 0 }, "1": { "text": "UP", "color": "green", "index": 1 } } } ],
+          "unit": "short",
+          "links": [ { "title": "Open", "url": "https://grafana.nerdsbythehour.com", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -821,9 +577,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "probe_success{instance=\"https://grafana.nerdsbythehour.com\"}",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
+          "instant": true, "legendFormat": "", "refId": "A"
         }
       ]
     },
@@ -835,31 +589,15 @@
       "gridPos": { "h": 3, "w": 4, "x": 16, "y": 17 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
-            ]
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "DOWN", "color": "red", "index": 0 },
-                "1": { "text": "UP", "color": "green", "index": 1 }
-              }
-            }
-          ],
-          "unit": "short"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "mappings": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 0 }, "1": { "text": "UP", "color": "green", "index": 1 } } } ],
+          "unit": "short",
+          "links": [ { "title": "Open", "url": "https://ha.nerdsbythehour.com", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -867,9 +605,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "probe_success{instance=\"https://ha.nerdsbythehour.com\"}",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
+          "instant": true, "legendFormat": "", "refId": "A"
         }
       ]
     },
@@ -881,31 +617,15 @@
       "gridPos": { "h": 3, "w": 4, "x": 20, "y": 17 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
-            ]
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": { "text": "DOWN", "color": "red", "index": 0 },
-                "1": { "text": "UP", "color": "green", "index": 1 }
-              }
-            }
-          ],
-          "unit": "short"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
+          "mappings": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 0 }, "1": { "text": "UP", "color": "green", "index": 1 } } } ],
+          "unit": "short",
+          "links": [ { "title": "Open", "url": "https://teslamate.nerdsbythehour.com", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -913,9 +633,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "probe_success{instance=\"https://teslamate.nerdsbythehour.com\"}",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
+          "instant": true, "legendFormat": "", "refId": "A"
         }
       ]
     },
@@ -937,24 +655,14 @@
       "gridPos": { "h": 4, "w": 4, "x": 0, "y": 21 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 },
-              { "color": "red", "value": 3 }
-            ]
-          },
-          "unit": "short",
-          "noValue": "0"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 3 } ] },
+          "unit": "short", "noValue": "0",
+          "links": [ { "title": "NetAlertX devices", "url": "https://netalertx.nerdsbythehour.com/devices.php", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -962,9 +670,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "netalertx_down_devices",
-          "instant": true,
-          "legendFormat": "down",
-          "refId": "A"
+          "instant": true, "legendFormat": "down", "refId": "A"
         }
       ]
     },
@@ -977,23 +683,14 @@
       "gridPos": { "h": 4, "w": 4, "x": 4, "y": 21 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "background", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 }
-            ]
-          },
-          "unit": "short",
-          "noValue": "0"
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 } ] },
+          "unit": "short", "noValue": "0",
+          "links": [ { "title": "NetAlertX devices", "url": "https://netalertx.nerdsbythehour.com/devices.php", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -1001,9 +698,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "netalertx_new_devices",
-          "instant": true,
-          "legendFormat": "new",
-          "refId": "A"
+          "instant": true, "legendFormat": "new", "refId": "A"
         }
       ]
     },
@@ -1015,15 +710,13 @@
       "gridPos": { "h": 4, "w": 4, "x": 8, "y": 21 },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto",
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center"
+        "textMode": "auto", "colorMode": "value", "graphMode": "none", "justifyMode": "center"
       },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "fixed", "fixedColor": "text" },
-          "unit": "short"
+          "unit": "short",
+          "links": [ { "title": "NetAlertX devices", "url": "https://netalertx.nerdsbythehour.com/devices.php", "targetBlank": true } ]
         },
         "overrides": []
       },
@@ -1031,9 +724,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "netalertx_connected_devices",
-          "instant": true,
-          "legendFormat": "connected",
-          "refId": "A"
+          "instant": true, "legendFormat": "connected", "refId": "A"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Every stat panel in `env-health-noc` now has `fieldConfig.defaults.links` so clicking a cell opens the relevant destination in a new tab (no hover menu — single link = direct navigation)
- Active Alerts table gets a panel-level link to https://prometheus.nerdsbythehour.com/alerts
- External-service panels (id 31–36) link directly to their respective sites
- Cluster/host panels (id 11–15, 21–26) link to the relevant Grafana dashboard or Prometheus targets page
- Network panels (id 41–43) link to https://netalertx.nerdsbythehour.com/devices.php

## Test plan

- [ ] Merge and wait for Grafana to reload the ConfigMap (~60s)
- [ ] Open https://grafana.nerdsbythehour.com/d/env-health-noc
- [ ] Click "New / unknown devices" → should open NetAlertX devices in a new tab
- [ ] Click "Firing Alerts" → should open Grafana alert list
- [ ] Click an external-service panel → should open that service's URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)