### PR TITLE
fix(geohazardwatch): bump liveness failureThreshold 3 → 5

### DIFF
--- a/apps/production/geohazardwatch/deployment.yaml
+++ b/apps/production/geohazardwatch/deployment.yaml
@@ -85,7 +85,7 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             timeoutSeconds: 10
-            failureThreshold: 3
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
## Summary

- Data-refresh job at ~05:00Z spikes response time, tripping the liveness probe (3 × 30s = 90s tolerance was too tight)
- Bump `failureThreshold` to 5 → 150s window; gives the refresh job time to complete without Kubernetes restarting the pod
- Readiness probe unchanged (still 3 failures — correct to gate traffic separately)

## Test plan

- [ ] Merge and let Flux apply; pod will rolling-restart once
- [ ] Watch `kubectl get pod -n geohazardwatch -w` — expect 0 restarts through the next data-refresh window (~05:00Z)

🤖 Generated with [Claude Code](https://claude.com/claude-code)