### PR TITLE
feat(yourphr): mount NAS archive into the app pod for in-app backups

### DIFF
--- a/apps/production/yourphr/deployment.yaml
+++ b/apps/production/yourphr/deployment.yaml
@@ -97,6 +97,11 @@ spec:
             - name: yourphr-config
               mountPath: /opt/fasten/config
               readOnly: true
+            # NAS archive (tank, 192.168.68.41) so the in-app backup (Admin -> Database) can write to
+            # the OS/NAS filesystem instead of only the node-local PVC. Choose /nas-backup as the
+            # destination in the card. yourphr#361.
+            - name: nas-archive
+              mountPath: /nas-backup
           resources:
             requests:
               cpu: 100m
@@ -130,3 +135,11 @@ spec:
         - name: yourphr-config
           configMap:
             name: yourphr-config
+        # Same NAS share the backup CronJob uses (192.168.68.41:/var/nfs/shared/jims mounted on the
+        # node at /mnt/tank/jims), pointed at data/archive/yourphr-backup. The app pod is already pinned
+        # to this node by the local-path PVC + Recreate strategy, so the hostPath resolves consistently.
+        # DirectoryOrCreate so the archive subdir is created on first use. yourphr#361.
+        - name: nas-archive
+          hostPath:
+            path: /mnt/tank/jims/data/archive/yourphr-backup
+            type: DirectoryOrCreate


### PR DESCRIPTION
## What

Mounts the NAS archive into the **yourphr app pod** so the v1.9.0 in-app backup (Admin → Database) can write to the **OS/NAS filesystem**, not just the node-local PVC.

- hostPath: node `/mnt/tank/jims/data/archive/yourphr-backup` → container **`/nas-backup`**
- `DirectoryOrCreate` (creates the archive subdir on first use)

## Why

Today the app can only write backups under `/opt/fasten/db` (the `local-path` PVC) — i.e. the **same volume as the database**, which is no good for disaster recovery. This mounts the same NAS share the existing `backup-cronjob.yaml` already uses (tank `192.168.68.41`), so backups land off the DB volume on the NAS.

## How to use

In **Admin → Database**, set the destination to **`/nas-backup`** (Browse will list it) → *Back up to server now* / the schedule writes `VACUUM`+gzip snapshots there.

## Notes

- The app pod is already pinned to this node by the `local-path` PVC + `Recreate` strategy, so the hostPath resolves consistently.
- Distinct from the CronJob's mount: the **app** `/nas-backup` → `…/data/archive/yourphr-backup`; the **CronJob** `/nas-backup` → `…/data/yourphr-backup` (separate pods, separate subdirs).
- Possible follow-up: the app's `VACUUM`+gzip backup is safer than the CronJob's raw `cp` of a live SQLite file — once this is validated, the CronJob could be retired.
- On merge, Flux applies it and the pod restarts (`Recreate`).

Refs jwilleke/yourphr#361