### PR TITLE
docs: fix all markdown lint violations (no rules disabled)

### DIFF
--- a/.claude-code-preferences.md
+++ b/.claude-code-preferences.md
@@ -17,6 +17,7 @@
   - Must justify why Kustomize won't work
 
 **Examples of good Kustomize deployments in this repo:**
+
 - `apps/production/jimswiki/` - Complex app with 38K+ files
 - `apps/production/teslamate/` - Multi-component application
 - `apps/production/landingpage/` - React application
@@ -30,6 +31,7 @@
 **Approved methods (in order of preference):**
 
 1. **SOPS + Age encryption** (PREFERRED)
+
    ```bash
    # Store secrets in .env files
    # Encrypt with: ./scripts/encrypt-env-files.sh <directory>
@@ -37,6 +39,7 @@
    ```
 
 2. **Cluster-only Kubernetes Secrets**
+
    ```bash
    # Create secret directly in cluster (NOT in git)
    kubectl create secret generic my-secret -n namespace \
@@ -45,6 +48,7 @@
    ```
 
 3. **Helm valuesFrom** (only if using Helm)
+
    ```yaml
    valuesFrom:
      - kind: Secret
@@ -52,6 +56,7 @@
    ```
 
 **What to NEVER do:**
+
 - ❌ Plaintext passwords in YAML files
 - ❌ API keys hardcoded in manifests
 - ❌ Secrets in environment variables in deployment files
@@ -73,6 +78,7 @@
 8. Troubleshooting - Common issues and solutions
 
 **Good examples:**
+
 - `apps/production/jimswiki/README.md`
 - `apps/production/authentik/SECRET-MANAGEMENT.md`
 
@@ -90,16 +96,19 @@
 ### 5. Git Practices
 
 **Commits:**
+
 - Use descriptive commit messages
 - Include "why" not just "what"
 - Reference related issues/docs
 - End with Claude Code attribution
 
 **Branches:**
+
 - Work directly on `master` (small repo, sole maintainer)
 - Can use branches for major changes if preferred
 
 **Never commit:**
+
 - Secrets (use SOPS)
 - Personal credentials
 - Age keys (*.agekey)
@@ -108,6 +117,7 @@
 ### 6. Resource Ownership
 
 **Prefer running as apps:apps (3003:3003) when possible:**
+
 ```yaml
 securityContext:
   runAsUser: 3003
@@ -129,6 +139,7 @@ securityContext:
 ### 8. Testing Before Commit
 
 **Always validate before committing:**
+
 ```bash
 # 1. Validate Kustomize
 kubectl kustomize apps/production/myapp/
@@ -149,6 +160,7 @@ kubectl logs -n namespace -l app=myapp
 ### 9. Migration Philosophy
 
 **Docker → Kubernetes migrations:**
+
 - Phase by phase (don't rush)
 - Test each service thoroughly
 - Keep Docker running until k8s proven stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Then:
 - Rules live in `.markdownlint.jsonc`; the editor, CLI, CI and agents all read that one file.
 <!-- KIT:END -->
 
-# Project Context for AI Agents
+## Project Context for AI Agents
 
 This file serves as the single source of truth for project context and state. All AI agents (Claude, Gemini, etc.) should read this file first when working on this project.
 
@@ -67,7 +67,7 @@ Implications:
 ## Jim's Global Preference
 
 - Remeber this is Using FLUX CI
-In all interactions and commit messages 
+In all interactions and commit messages
 - Be concise and sacrifice grammar for consistion
 - We do Test-Driven-Developement
 - DRY (Don't Repeat Yourself) principle in Documentation and Code. Refer to other Documents.
@@ -143,6 +143,7 @@ mj-infra-flux/
 - **docker-migration.md** - Migration strategy from Docker to Kubernetes
 
 **Application READMEs:**
+
 - Each app in `apps/production/*/README.md` has detailed documentation
 
 ## Key Principles (MANDATORY)
@@ -156,6 +157,7 @@ mj-infra-flux/
 - ❌ Must justify why Kustomize won't work before considering Helm
 
 **Good Kustomize Examples:**
+
 - `apps/production/jimswiki/` - Complex app with 38K+ files
 - `apps/production/teslamate/` - Multi-component application
 - `apps/production/database/` - Shared PostgreSQL
@@ -168,6 +170,7 @@ mj-infra-flux/
 **Approved methods (in priority order):**
 
 1. **SOPS + Age encryption** (PREFERRED)
+
    ```bash
    # Store secrets in .env files
    # Encrypt with: ./scripts/encrypt-env-files.sh <directory>
@@ -175,6 +178,7 @@ mj-infra-flux/
    ```
 
 2. **Cluster-only Kubernetes Secrets**
+
    ```bash
    # Create directly in cluster (NOT in git)
    kubectl create secret generic my-secret -n namespace --from-literal=key="value"
@@ -188,6 +192,7 @@ mj-infra-flux/
 ### 3. Documentation Requirements
 
 Every application MUST have a README.md with:
+
 1. Overview - What it does
 2. URL - Where it's accessed
 3. Data Paths - Where persistent data is stored
@@ -202,6 +207,7 @@ Every application MUST have a README.md with:
 ### 4. Testing Before Commit
 
 **Always validate before committing:**
+
 ```bash
 # 1. Validate Kustomize
 kubectl kustomize apps/production/myapp/
@@ -222,20 +228,23 @@ kubectl logs -n namespace -l app=myapp
 ## Production Services
 
 ### Core Infrastructure
+
 - **Traefik** (kube-system) - Ingress controller
 - **cert-manager** (cert-manager) - Let's Encrypt certificates
 - **Flux** (flux-system) - GitOps automation
 
 ### Shared Services
+
 - **PostgreSQL** (database) - Shared database for multiple apps
 - **Mosquitto** (messaging) - MQTT broker for IoT
 - **Grafana** (monitoring) - Dashboards and monitoring
 - **Authentik** (authentik) - SSO/IdP for all protected services
 
 ### Applications
+
 - **Landing Page** - Public landing page at nerdsbythehour.com
 - **JimsWiki** - 38,004 pages wiki (JSPWiki)
-- **TeslaMate** - Vehicle tracking 
+- **TeslaMate** - Vehicle tracking
 - **Home Assistant** - Home automation
 - **Hoarder** - Bookmark and content management
 - **Guest Services** - Public services (OpenSpeedTest, whoami)
@@ -247,6 +256,7 @@ kubectl logs -n namespace -l app=myapp
 ## Data Organization
 
 ### NFS Mount (Persistent, Backed Up)
+
 ```
 /home/jim/docs/data/systems/
 ├── mj-infra-flux/          # k3s application data
@@ -261,6 +271,7 @@ kubectl logs -n namespace -l app=myapp
 ```
 
 ### Local SSD (Fast, Ephemeral)
+
 ```
 /mnt/local-k3s-data/
 ├── postgresql/             # PostgreSQL data (8Gi)
@@ -272,6 +283,7 @@ kubectl logs -n namespace -l app=myapp
 ## Common Commands
 
 ### Flux Operations
+
 ```bash
 # Force reconciliation
 flux reconcile kustomization flux-system --with-source
@@ -287,6 +299,7 @@ flux reconcile kustomization apps
 ```
 
 ### Kustomize Operations
+
 ```bash
 # Validate manifests
 kubectl kustomize apps/production/myapp/
@@ -299,6 +312,7 @@ kubectl apply -k apps/production/myapp/
 ```
 
 ### Secret Management
+
 ```bash
 # Encrypt secrets with SOPS + Age
 ./scripts/encrypt-env-files.sh apps/production/myapp/
@@ -309,6 +323,7 @@ kubectl create secret generic my-secret -n namespace \
 ```
 
 ### Debugging
+
 ```bash
 # Check pod status
 kubectl get pods -n namespace
@@ -326,24 +341,28 @@ kubectl port-forward -n namespace svc/myservice 8080:80
 ## Key Decisions
 
 ### Migration to Kubernetes
+
 - **Decision:** Migrate all Docker Compose services to k3s
 - **Status:** Phase 3 Complete - All services migrated
 - **Rationale:** Better orchestration, scaling, and GitOps integration
 - **Documentation:** `docker-migration.md`
 
 ### Kustomize Over Helm
+
 - **Decision:** Use Kustomize for all new deployments
 - **Rationale:** Transparency, simplicity, better GitOps integration
 - **Exception:** Existing Helm charts (e.g., Authentik) acceptable
 - **Documentation:** `DEPLOYMENT-GUIDELINES.md`
 
 ### SOPS + Age for Secrets
+
 - **Decision:** Use SOPS + Age encryption for all secrets in git
 - **Rationale:** Security, audit trail, GitOps compatibility
 - **Alternative:** Cluster-only secrets for highly sensitive data
 - **Documentation:** `SECURITY-INCIDENT.md` (lessons learned)
 
 ### Port Range for Applications
+
 - **Decision:** Run apps within ports 9200-9299 when possible
 - **User/Group:** Run as apps:apps (3003:3003) when possible
 - **Rationale:** Consistency, security, easy firewall rules
@@ -353,6 +372,7 @@ kubectl port-forward -n namespace svc/myservice 8080:80
 > **Frozen as of 2026-05-22.** Operational history is consolidated at [`jwilleke/deby:docs/project_log.md`](https://github.com/jwilleke/deby/blob/master/docs/project_log.md). The entries below are preserved as historical record; do not add new session-shaped entries here.
 
 ### Session: 2025-12-01 (Morning)
+
 - Agent: Claude
 - Work Done:
   - Initialized AGENTS.md with complete project context
@@ -362,9 +382,10 @@ kubectl port-forward -n namespace svc/myservice 8080:80
 - Files Modified: AGENTS.md (created), CLAUDE.md (removed), README.md
 
 ### Session: 2025-12-01 (Afternoon)
+
 - Agent: Claude
 - Work Done:
-  - Fixed amdwiki service (https://amd.nerdsbythehour.com) which was showing "no available server"
+  - Fixed amdwiki service (<https://amd.nerdsbythehour.com>) which was showing "no available server"
   - Rebuilt amdwiki Docker image from source (missing config files)
   - Imported rebuilt image to k3s cluster
   - Copied config files from Docker image to host directory at `/home/jim/docs/data/systems/mj-infra-flux/amdwiki/config/`
@@ -376,6 +397,7 @@ kubectl port-forward -n namespace svc/myservice 8080:80
   - `/home/jim/docs/data/systems/mj-infra-flux/amdwiki/config/app-production-config.json` (added install.completed flag)
 
 ### Session: 2025-12-10 (Evening)
+
 - Agent: Claude
 - Work Done:
   - Fixed Home Assistant proxy connectivity issue (ha.nerdsbythehour.com)
@@ -391,6 +413,7 @@ kubectl port-forward -n namespace svc/myservice 8080:80
   - `apps/production/home-assistant-proxy/ingressroute.yaml` (created, replaces Ingress with proper WebSocket support)
 
 ### Session: 2025-12-11 (Evening)
+
 - Agent: Claude
 - Work Done:
   - Added zero-threat.html static page to landing page unprotected
@@ -405,6 +428,7 @@ kubectl port-forward -n namespace svc/myservice 8080:80
   - `/opt/traefik/landingpage/Dockerfile` (updated to use serve.json for routing control)
 
 ### Session: 2026-05-09 (geohazardwatch image automation end-to-end)
+
 - Agent: Claude Opus 4.7
 - Work Done:
   - Closed issue #64. Image automation now runs end-to-end for geohazardwatch: GHCR scan → ImagePolicy resolves to highest semver in range → fluxcdbot pushes auto-bump commit → Flux reconciles → rolling deploy.
@@ -419,6 +443,7 @@ kubectl port-forward -n namespace svc/myservice 8080:80
   - Re-encrypt `apps/production/monitoring/prometheus/.env.secret.prometheus-self-scrape.encrypted` and `apps/production/monitoring/prometheus-alertmanager/.env.secret.alertmanager.encrypted` from `age1nur86…` to the unified `age1sr8j…` — currently apply as garbled-but-functional env vars; blocks any future "enable SOPS on apps Kustomization" cleanup.
 
 ### Session: 2025-12-11 (Night)
+
 - Agent: Claude
 - Work Done:
   - Reviewed ZeroThreat security scan report for nerdsbythehour.com
@@ -438,11 +463,13 @@ kubectl port-forward -n namespace svc/myservice 8080:80
 **Status:** In Progress - WebSocket failing due to HTTP/2 limitation
 
 **Problem:**
+
 - Home Assistant accessible at ha.nerdsbythehour.com but frontend shows "Unable to connect"
 - Root cause: Traefik's standard Ingress uses HTTP/2, but WebSocket requires HTTP/1.1
 - Traefik's HTTP/2 doesn't support the Upgrade header needed for WebSocket connections
 
 **What's Working:**
+
 - DNS resolution fixed (192.168.68.71 - correct Traefik IP)
 - Home Assistant backend accessible at 192.168.68.20:8123
 - HTTP proxy working through Traefik
@@ -450,15 +477,18 @@ kubectl port-forward -n namespace svc/myservice 8080:80
 - Home Assistant config updated with external/internal URLs
 
 **Solution Applied:**
+
 - Switched from standard Ingress to Traefik IngressRoute
 - IngressRoute properly handles HTTP/1.1 protocol for WebSocket connections
 - Created: `/home/jim/Documents/mj-infra-flux/apps/production/home-assistant-proxy/ingressroute.yaml`
 
 **Next Steps:**
+
 - Verify WebSocket connection works after IngressRoute deployment
 - Test frontend can establish connection to backend API
 
 ### Potential Improvements
+
 - Create port allocation table for all applications (ports 9200-9220)
 - Monitor for security updates on all containers
 - Review and optimize resource allocations as needed
@@ -495,10 +525,12 @@ kubectl port-forward -n namespace svc/myservice 8080:80
 ### Security Model
 
 **Authentication Flow:**
+
 - Public services: No authentication (landing page, guest services)
 - Protected services: Authentik ForwardAuth (jimswiki, teslamate, grafana, home assistant)
 
 **Secrets Management:**
+
 - SOPS + Age encryption for secrets in git
 - Cluster-only secrets for highly sensitive data
 - Never commit plaintext secrets (see SECURITY-INCIDENT.md)
@@ -506,6 +538,7 @@ kubectl port-forward -n namespace svc/myservice 8080:80
 ### Resource Ownership
 
 Prefer running as apps:apps (3003:3003):
+
 ```yaml
 securityContext:
   runAsUser: 3003
@@ -581,10 +614,10 @@ kubectl get pods -A
 
 ## References
 
-- **GitHub Repository:** https://github.com/jwilleke/mj-infra-flux
-- **Original Inspiration:** https://github.com/activescott/home-infra-k8s-flux
-- **Flux Documentation:** https://fluxcd.io/
-- **Kustomize Documentation:** https://kustomize.io/
+- **GitHub Repository:** <https://github.com/jwilleke/mj-infra-flux>
+- **Original Inspiration:** <https://github.com/activescott/home-infra-k8s-flux>
+- **Flux Documentation:** <https://fluxcd.io/>
+- **Kustomize Documentation:** <https://kustomize.io/>
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,9 +14,10 @@ Complete Kubernetes (k3s) infrastructure running on `192.168.68.71` (deby) with 
 - **Cluster IP:** 192.168.68.71 (hostname: deby)
 
 ### Coding Standard:** DRY (Don't Repeat Yourself) principle
+
 - If logic repeats more than twice, refactor into reusable components
- - Abstract repeated logic into functions, classes, or modules
- - Improves maintainability, reduces bugs, simplifies updates
+- Abstract repeated logic into functions, classes, or modules
+- Improves maintainability, reduces bugs, simplifies updates
 
 ### Key Technologies
 
@@ -43,12 +44,14 @@ Complete Kubernetes (k3s) infrastructure running on `192.168.68.71` (deby) with 
 ### Public Access (No Authentication)
 
 **Landing Page:** `https://nerdsbythehour.com`
+
 - `/` - Main landing page
 - `/guest` - Guest page with public service links
   - OpenSpeedTest (`/speed`)
   - whoami (`https://deby.nerdsbythehour.com`)
 
 **CDN:** `https://cdn.nerdsbythehour.com`
+
 - Static asset server for icons, logos, and shared resources
 
 ### Authenticated Access (Authentik SSO)
@@ -56,6 +59,7 @@ Complete Kubernetes (k3s) infrastructure running on `192.168.68.71` (deby) with 
 **Members Portal:** `https://nerdsbythehour.com/members` → Redirects to Authentik User Library
 
 Protected services accessible after Authentik login at `https://auth.nerdsbythehour.com/if/user/#/library`:
+
 - **Home Assistant** - `https://ha.nerdsbythehour.com` (private DNS only)
 - **TeslaMate** - `https://teslamate.nerdsbythehour.com` (vehicle tracking)
 - **Grafana** - `https://grafana.nerdsbythehour.com` (dashboards)
@@ -158,6 +162,7 @@ Authentik Protected (ForwardAuth - TO BE ENABLED)
 ### Authentik Integration (Pending)
 
 Each protected service will have:
+
 1. **Authentik Application** - Configured in Authentik UI
 2. **Authentik Provider** - ForwardAuth provider with auth URL
 3. **Traefik Middleware** - ForwardAuth middleware CRD
@@ -211,6 +216,7 @@ k3s Traefik Ingress (192.168.68.71)
 ### Public DNS (Cloudflare)
 
 Points to your public IP:
+
 - `nerdsbythehour.com` → Public IP
 - `*.nerdsbythehour.com` → Public IP (includes cdn.nerdsbythehour.com)
 - Port forward 443 → 192.168.68.71:443
@@ -218,9 +224,11 @@ Points to your public IP:
 ### Private DNS (Local Network Only)
 
 Internal services that don't need public access:
+
 - `ha.nerdsbythehour.com` → `192.168.68.71` (local DNS only)
 
 Configure in:
+
 - Router DNS override, or
 - Pi-hole local DNS, or
 - `/etc/hosts` on client machines
@@ -228,21 +236,25 @@ Configure in:
 ## Security Model
 
 ### Public Layer
+
 - Let's Encrypt TLS certificates
 - Cloudflare DDoS protection (optional)
 - Rate limiting (Traefik)
 
 ### Authentication Layer
+
 - Authentik SSO for all protected services
 - Single sign-on across all apps
 - Group-based access control
 
 ### Application Layer
+
 - Each service runs in isolated namespace
 - Network policies (optional - can be added)
 - RBAC for Kubernetes resources
 
 ### Secrets Management
+
 - SOPS + Age encryption for secrets in git
 - Cluster-only secrets for sensitive data
 - Never commit plaintext secrets
@@ -250,17 +262,20 @@ Configure in:
 ## Migration Status
 
 ### ✅ Phase 1: Stateless Applications
+
 - Landing page
 - OpenSpeedTest
 - whoami
 
 ### ✅ Phase 2: Shared Infrastructure + TeslaMate
+
 - PostgreSQL
 - Mosquitto MQTT
 - Grafana
 - TeslaMate (with historical data)
 
 ### ✅ Phase 4: Home Assistant Proxy
+
 - External service proxy configured
 - Ready for Authentik integration
 
@@ -269,6 +284,7 @@ Configure in:
 ### 1. Authentik ForwardAuth Configuration
 
 Create ForwardAuth middleware and enable on:
+
 - [ ] Landing page `/members`
 - [ ] TeslaMate
 - [ ] Grafana
@@ -277,6 +293,7 @@ Create ForwardAuth middleware and enable on:
 ### 2. Home Assistant Trusted Proxies
 
 Update HA configuration to trust k3s:
+
 ```yaml
 http:
   trusted_proxies:
@@ -287,6 +304,7 @@ http:
 ### 3. Docker Cleanup (Optional)
 
 After verification period:
+
 - Stop Docker containers
 - Remove unused images
 - Archive `/opt/traefik/` for reference
@@ -296,11 +314,13 @@ After verification period:
 ### Critical Data Backups
 
 **Must backup:**
+
 1. Config: `/home/jim/docs/data/systems/mj-infra-flux/`
-3. PostgreSQL: Database dumps from `/mnt/local-k3s-data/postgresql/`
-4. Kubernetes secrets: Export and store securely
+2. PostgreSQL: Database dumps from `/mnt/local-k3s-data/postgresql/`
+3. Kubernetes secrets: Export and store securely
 
 **Can regenerate:**
+
 - Logs
 - Lucene indices
 - Container images (rebuild from Dockerfile)

--- a/DEPLOYMENT-GUIDELINES.md
+++ b/DEPLOYMENT-GUIDELINES.md
@@ -15,16 +15,19 @@
 ### When to Use Helm
 
 Use Helm **only** when:
+
 - Complex third-party applications with extensive configuration
 - Active upstream Helm chart with frequent updates
 - Converting would require significant effort
 
 **Current Helm deployments** (to be migrated when time permits):
+
 - Authentik (SSO/IdP)
 
 ### Examples of Kustomize Deployments
 
 See `apps/production/` for reference implementations:
+
 - ✅ `landingpage/` - React app
 - ✅ `openspeedtest/` - Custom image
 - ✅ `whoami/` - Simple service
@@ -41,12 +44,14 @@ See `apps/production/` for reference implementations:
 ### Approved Methods
 
 1. **SOPS + Age (Preferred)**
+
    ```bash
    # Encrypt secrets with SOPS
    ./scripts/encrypt-env-files.sh <directory>
    ```
 
 2. **Cluster-only Secrets**
+
    ```bash
    # Create secret directly in cluster (not in git)
    kubectl create secret generic my-secret -n my-namespace \
@@ -54,6 +59,7 @@ See `apps/production/` for reference implementations:
    ```
 
 3. **Helm valuesFrom** (for Helm deployments)
+
    ```yaml
    valuesFrom:
      - kind: Secret
@@ -123,6 +129,7 @@ kubectl apply -k apps/production/myapp/
 See `docker-migration.md` for the complete migration process from Docker Compose to Kubernetes.
 
 Key principles:
+
 - ✅ Preserve data paths
 - ✅ Use hostPath for persistent data
 - ✅ Document volume mounts

--- a/MCP-SETUP.md
+++ b/MCP-SETUP.md
@@ -5,11 +5,13 @@ This repository uses MCP servers to enable Claude Code to interact with external
 ## Configured MCP Servers
 
 ### 1. jimsmcp
+
 Custom MCP server for managing infrastructure.
 
 **Location:** `apps/production/jimsmcp/`
 
 ### 2. Authentik MCP Server
+
 Provides full API access to Authentik for automated user, group, and application management.
 
 **Configuration:** Encrypted with SOPS+Age
@@ -20,6 +22,7 @@ Provides full API access to Authentik for automated user, group, and application
 ### Prerequisites
 
 1. **SOPS installed:**
+
    ```bash
    # Already installed at /usr/local/bin/sops
    sops --version
@@ -31,6 +34,7 @@ Provides full API access to Authentik for automated user, group, and application
    - The private key is also stored in Kubernetes secret: `flux-system/sops-age`
 
 3. **jq installed:**
+
    ```bash
    sudo apt install jq
    ```
@@ -44,6 +48,7 @@ Run the update script to decrypt credentials and configure MCP:
 ```
 
 This script:
+
 1. Decrypts `.env.secret.mcp-authentik.encrypted` using SOPS+Age
 2. Extracts `AUTHENTIK_BASE_URL` and `AUTHENTIK_TOKEN`
 3. Updates `~/.config/claude-code/mcp.json` with the configuration
@@ -71,6 +76,7 @@ After running the update script, restart Claude Code to load the MCP servers:
 `.env.secret.mcp-authentik.encrypted` (committed to git)
 
 Contains:
+
 - `AUTHENTIK_BASE_URL` - Authentik instance URL
 - `AUTHENTIK_TOKEN` - API token with full access
 
@@ -116,12 +122,13 @@ chmod 600 home-infra-private.agekey
 ### Rotate Authentik API Token
 
 1. **Create new token in Authentik:**
-   - Go to: https://auth.nerdsbythehour.com
+   - Go to: <https://auth.nerdsbythehour.com>
    - Navigate to Directory → Tokens
    - Create new token with API intent
    - Copy the token
 
 2. **Update encrypted file:**
+
    ```bash
    # Create temp env file
    cat > /tmp/mcp-authentik.env <<EOF
@@ -142,11 +149,13 @@ chmod 600 home-infra-private.agekey
    ```
 
 3. **Update MCP config:**
+
    ```bash
    ./scripts/update-mcp-config.sh
    ```
 
 4. **Commit the new encrypted file:**
+
    ```bash
    git add .env.secret.mcp-authentik.encrypted
    git commit -m "Rotate Authentik MCP token"
@@ -159,33 +168,40 @@ chmod 600 home-infra-private.agekey
 After setup, Claude Code can use these Authentik MCP tools:
 
 ### User Management
+
 - Create, read, update, delete users
 - Manage user attributes and groups
 - Reset passwords
 
 ### Group Management
+
 - Create, read, update, delete groups
 - Manage group memberships
 
 ### Application Management
+
 - Create, read, update, delete applications
 - Configure proxy providers
 - Manage application settings
 
 ### Provider Management
+
 - Create proxy providers
 - Configure OAuth2/OIDC providers
 - Manage provider settings
 
 ### Flow Management
+
 - View and manage authentication flows
 - Configure flow bindings
 
 ### Event Monitoring
+
 - Search and filter events
 - Monitor system activity
 
 ### Token Management
+
 - Create API tokens
 - Manage token permissions
 
@@ -194,16 +210,19 @@ After setup, Claude Code can use these Authentik MCP tools:
 ### MCP Server Not Loading
 
 1. Check config syntax:
+
    ```bash
    cat ~/.config/claude-code/mcp.json | jq .
    ```
 
 2. Verify credentials are decrypted:
+
    ```bash
    ./scripts/update-mcp-config.sh
    ```
 
 3. Check SOPS can decrypt:
+
    ```bash
    export SOPS_AGE_KEY_FILE="$(pwd)/home-infra-private.agekey"
    sops decrypt .env.secret.mcp-authentik.encrypted
@@ -212,6 +231,7 @@ After setup, Claude Code can use these Authentik MCP tools:
 ### Authentication Errors
 
 1. Verify token is valid:
+
    ```bash
    TOKEN=$(sops decrypt --extract '["AUTHENTIK_TOKEN"]' .env.secret.mcp-authentik.encrypted)
    curl -H "Authorization: Bearer $TOKEN" https://auth.nerdsbythehour.com/api/v3/core/users/
@@ -222,12 +242,14 @@ After setup, Claude Code can use these Authentik MCP tools:
 ### Permission Denied Errors
 
 1. Check config file permissions:
+
    ```bash
    ls -l ~/.config/claude-code/mcp.json
    # Should be: -rw------- (600)
    ```
 
 2. Check age key permissions:
+
    ```bash
    ls -l home-infra-private.agekey
    # Should be: -rw------- (600)

--- a/MONITORING_IMPROVEMENT_PLAN.md
+++ b/MONITORING_IMPROVEMENT_PLAN.md
@@ -21,6 +21,7 @@ Your infrastructure currently lacks comprehensive health checking and proactive 
 ## Current Monitoring State
 
 ### What's Working ✅
+
 - Prometheus metrics collection (Kubernetes pods, nodes, system metrics)
 - Grafana visualization dashboards
 - Alertmanager with Telegram notifications
@@ -29,6 +30,7 @@ Your infrastructure currently lacks comprehensive health checking and proactive 
 - Blackbox exporter (deployed but underutilized)
 
 ### Critical Gaps ❌
+
 1. **No application health checks** - Services can fail silently
 2. **No dependency monitoring** - PostgreSQL/MQTT failures not detected
 3. **No external endpoint monitoring** - Public services not checked from outside
@@ -46,6 +48,7 @@ Your infrastructure currently lacks comprehensive health checking and proactive 
 **Symptoms**: No vehicle data collection since November 2024
 
 **Monitoring Gaps**:
+
 - No alert if TeslaMate pod crashes/restarts
 - No check if PostgreSQL connection fails
 - No alert if MQTT broker becomes unavailable
@@ -54,6 +57,7 @@ Your infrastructure currently lacks comprehensive health checking and proactive 
 **Root Cause Likely**: Silent failure in one of the dependencies
 
 **Alert Required**:
+
 ```yaml
 alert: TeslaMateDataCollectionFailed
 expr: increase(teslamate_api_calls_total[10m]) == 0
@@ -65,9 +69,10 @@ severity: critical
 
 ### Issue #2: AMD Wiki - Server Not Found
 
-**Symptoms**: https://amd.nerdsbythehour.com/ returns "server not found"
+**Symptoms**: <https://amd.nerdsbythehour.com/> returns "server not found"
 
 **Monitoring Gaps**:
+
 - No external HTTP health check on the endpoint
 - No alert if Ingress route misconfigured
 - No alert if pod fails to start
@@ -76,6 +81,7 @@ severity: critical
 **Root Cause**: Service unreachable (DNS, Ingress, or Pod issue)
 
 **Alert Required**:
+
 ```yaml
 alert: ServiceEndpointDown
 expr: probe_success{endpoint="amd"} == 0
@@ -89,9 +95,10 @@ annotations:
 
 ### Issue #3: JimsWiki - 404 Error
 
-**Symptoms**: https://jimswiki.nerdsbythehour.com/ returns 404
+**Symptoms**: <https://jimswiki.nerdsbythehour.com/> returns 404
 
 **Monitoring Gaps**:
+
 - No alert for application initialization failures
 - No check if NFS mount is accessible
 - No monitoring of disk space
@@ -100,6 +107,7 @@ annotations:
 **Root Cause**: Likely NFS mount unmounted or data corruption
 
 **Alert Required**:
+
 ```yaml
 alert: JimsWikiApplicationError
 expr: probe_http_status_code{endpoint="jimswiki"} != 200
@@ -114,6 +122,7 @@ severity: critical
 **Symptoms**: "Replaying WAL (28/805)" message, extended startup
 
 **Monitoring Gaps**:
+
 - No alert if Prometheus takes too long to start
 - No monitoring of WAL replay progress
 - No alert for unclean shutdown
@@ -121,6 +130,7 @@ severity: critical
 **Root Cause**: Previous crash or hard shutdown
 
 **Alert Required**:
+
 ```yaml
 alert: PrometheusStartupDelayed
 expr: time() - prometheus_tsdb_symbol_table_size_bytes > 600 AND prometheus_tsdb_wal_replay_status != 1
@@ -135,6 +145,7 @@ severity: warning
 **Symptoms**: TeslaMate dashboard link redirects to Grafana login instead of serving dashboard
 
 **Monitoring Gaps**:
+
 - No health check for Grafana-Prometheus datasource connection
 - No alert if authentication middleware fails
 - No check if Authentik is accessible
@@ -142,6 +153,7 @@ severity: warning
 **Root Cause**: Authentik session/authentication misconfiguration
 
 **Alert Required**:
+
 ```yaml
 alert: GrafanaAuthenticationFailure
 expr: increase(grafana_dashboard_access_total{status="401"}[5m]) > 10
@@ -156,6 +168,7 @@ severity: warning
 **Symptoms**: "Unable to connect to Home Assistant. Retrying in 23 seconds..."
 
 **Monitoring Gaps**:
+
 - No alert for pod crash/restart
 - No check if port binding failed
 - No alert for OOM kills
@@ -164,6 +177,7 @@ severity: warning
 **Root Cause**: Pod not running or not responding on configured port
 
 **Alert Required**:
+
 ```yaml
 alert: HomeAssistantPodDown
 expr: up{job="home-assistant"} == 0
@@ -440,12 +454,14 @@ groups:
 **Recommended**: Deploy Loki + Promtail for centralized logging
 
 **Benefits**:
+
 - Single source for all pod logs
 - Search by labels (namespace, pod, container)
 - Linked to Prometheus metrics
 - Retention and compression
 
 **Implementation Steps**:
+
 1. Deploy Promtail to collect logs from all pods (DaemonSet)
 2. Deploy Loki to store logs
 3. Add Loki as Grafana datasource
@@ -458,6 +474,7 @@ groups:
 **Create these alert rule files**:
 
 `apps/production/monitoring/prometheus/config/alerting-rules.kubernetes.yaml`:
+
 ```yaml
 groups:
   - name: kubernetes_alerts
@@ -506,6 +523,7 @@ groups:
 **Create Service Health Dashboard in Grafana**:
 
 Components:
+
 - Service status table (probe_success by instance)
 - Availability % for each service (past 24h, 7d, 30d)
 - Response time graph
@@ -518,6 +536,7 @@ Components:
 ## Implementation Roadmap
 
 ### Phase 1: Immediate (Week 1-2) - CRITICAL
+
 - [ ] Enable Blackbox monitoring for public endpoints
 - [ ] Add alert rules for endpoint failures
 - [ ] Add TeslaMate metrics scraping
@@ -525,6 +544,7 @@ Components:
 - [ ] Test Telegram notifications work for critical alerts
 
 ### Phase 2: Short-term (Week 3-4) - HIGH
+
 - [ ] Add pod health/restart tracking
 - [ ] Create Kubernetes cluster health rules
 - [ ] Add JimsWiki/AMD Wiki application-level checks
@@ -532,12 +552,14 @@ Components:
 - [ ] Document runbooks for each alert
 
 ### Phase 3: Medium-term (Month 2) - MEDIUM
+
 - [ ] Deploy log aggregation (Loki + Promtail)
 - [ ] Create central status dashboard
 - [ ] Add SLA/uptime tracking
 - [ ] Set up trace collection (optional)
 
 ### Phase 4: Long-term (Month 3+) - LOW
+
 - [ ] Service mesh observability (Istio/Linkerd)
 - [ ] Advanced anomaly detection
 - [ ] Cost tracking per service
@@ -586,6 +608,7 @@ Components:
 ## Files to Create/Modify
 
 ### New Files
+
 ```
 apps/production/monitoring/prometheus/config/
 ├── scrape-configs.blackbox.yaml        # Endpoint monitoring
@@ -598,6 +621,7 @@ apps/production/monitoring/prometheus/config/
 ```
 
 ### Modified Files
+
 ```
 apps/production/monitoring/prometheus/kustomization.yaml  # Include new configs
 apps/production/teslamate/teslamate-deployment.yaml       # Add Prometheus metrics
@@ -618,8 +642,7 @@ apps/production/monitoring/grafana/                       # Add health dashboard
 
 ## References
 
-- Prometheus alerting rules: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
-- Blackbox exporter: https://github.com/prometheus/blackbox_exporter
-- Alertmanager routing: https://prometheus.io/docs/alerting/latest/configuration/
-- Grafana dashboards: https://grafana.com/grafana/dashboards/
-
+- Prometheus alerting rules: <https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/>
+- Blackbox exporter: <https://github.com/prometheus/blackbox_exporter>
+- Alertmanager routing: <https://prometheus.io/docs/alerting/latest/configuration/>
+- Grafana dashboards: <https://grafana.com/grafana/dashboards/>

--- a/SETUP.md
+++ b/SETUP.md
@@ -8,7 +8,7 @@ Step-by-step instructions to set up the project locally for development.
 
 - **Node.js**: v18 or higher
   - Check: `node --version`
-  - Download: https://nodejs.org/
+  - Download: <https://nodejs.org/>
 - **npm**: v9 or higher
   - Check: `npm --version`
 - **Git**: Latest version
@@ -36,6 +36,7 @@ npm install
 ```
 
 Or with other package managers:
+
 ```bash
 yarn install
 pnpm install

--- a/apps/base/monitoring/README.md
+++ b/apps/base/monitoring/README.md
@@ -2,14 +2,14 @@
 
 Used to monitor the state of installed objects within Kubernetes, rather than the Kubernetes cluster itself (like metrics-server).
 
-The **available metrics** are documented at: https://github.com/kubernetes/kube-state-metrics/tree/main/docs
+The **available metrics** are documented at: <https://github.com/kubernetes/kube-state-metrics/tree/main/docs>
 
 ## Installation / Deployment
 
 > To deploy this project, you can simply run kubectl apply -f examples/standard and a Kubernetes service and deployment will be created
-> – https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment
+> – <https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment>
 
-They publish a kustomization file there, so we can just use kustomize to import it directly: https://github.com/kubernetes/kube-state-metrics/blob/v2.15.0/examples/standard/kustomization.yaml
+They publish a kustomization file there, so we can just use kustomize to import it directly: <https://github.com/kubernetes/kube-state-metrics/blob/v2.15.0/examples/standard/kustomization.yaml>
 
 Then we need to patch a couple things:
 
@@ -18,11 +18,11 @@ Then we need to patch a couple things:
 > As a general rule, you should allocate:
 > 250MiB memory
 > 0.1 cores
-> – https://github.com/kubernetes/kube-state-metrics#resource-recommendation
+> – <https://github.com/kubernetes/kube-state-metrics#resource-recommendation>
 
 ### 2. Metrics Scrape Endpoints
 
-As described in my metrics setup for prometheus at https://github.com/activescott/home-infra/blob/main/k8s/apps/monitoring/README.md, we can add a couple annotations to the service. Kube State Metrics [explains](https://github.com/kubernetes/kube-state-metrics#overview) that that their _metrics are exported on the HTTP endpoint `/metrics` on the listening port (default 8080)._
+As described in my metrics setup for prometheus at <https://github.com/activescott/home-infra/blob/main/k8s/apps/monitoring/README.md>, we can add a couple annotations to the service. Kube State Metrics [explains](https://github.com/kubernetes/kube-state-metrics#overview) that that their _metrics are exported on the HTTP endpoint `/metrics` on the listening port (default 8080)._
 So:
 
 ```yaml

--- a/apps/base/traefik-ingress/README.md
+++ b/apps/base/traefik-ingress/README.md
@@ -1,6 +1,6 @@
 # traefik ingress
 
-K3S bundles Traefik for it's ingress controller as explained [here](https://docs.k3s.io/networking#traefik-ingress-controller) and implemented [here](https://github.com/k3s-io/k3s/blob/v1.25.3%2Bk3s1/manifests/traefik.yaml). However, on TrueNAS when they install k3s they disable/remove the traefik ingress controller. so `Ingress` resources have no effect. This adds Traefik back as the default ingress controller .
+K3S bundles Traefik for it's ingress controller as explained in the [K3s networking docs](https://docs.k3s.io/networking#traefik-ingress-controller) and implemented in the [K3s Traefik manifest](https://github.com/k3s-io/k3s/blob/v1.25.3%2Bk3s1/manifests/traefik.yaml). However, on TrueNAS when they install k3s they disable/remove the traefik ingress controller. so `Ingress` resources have no effect. This adds Traefik back as the default ingress controller .
 
 ## Helm
 

--- a/apps/production/authentik/README.md
+++ b/apps/production/authentik/README.md
@@ -3,7 +3,8 @@
 ## Current Status
 
 ✅ **Completed:**
-- Authentik deployed via Flux at https://auth.nerdsbythehour.com
+
+- Authentik deployed via Flux at <https://auth.nerdsbythehour.com>
 - PostgreSQL and Redis persistence configured
 - Let's Encrypt certificate issued
 - Traefik ForwardAuth middleware created
@@ -12,21 +13,23 @@
 > **Note:** This guide was originally written using Filebrowser as the worked example for an Authentik-protected application. That deployment was removed on 2026-05-05 (the SMB stack it served was orphaned — see the related cleanup commit). The Step 1 / Step 2 / Step 3 instructions below still reference Filebrowser by name; treat them as historical reference for the shape of the setup, and substitute your own application's name and URLs when adapting.
 
 🔧 **Pending Configuration:**
+
 - Complete OAuth2/Proxy Provider setup in Authentik UI (steps below)
 - Test authentication flow
 
 ## Initial Setup
 
-1. Access Authentik at: https://auth.nerdsbythehour.com/if/flow/initial-setup/
+1. Access Authentik at: <https://auth.nerdsbythehour.com/if/flow/initial-setup/>
 2. Set password for the default `akadmin` user
 3. Login with `akadmin` credentials
 
 ## Configure OAuth2/Proxy Provider for Traefik ForwardAuth
 
 **To access the Admin Interface:**
+
 - Click on your username in the top right corner
 - Select **Admin Interface** from the dropdown
-- OR directly access: https://auth.nerdsbythehour.com/if/admin/
+- OR directly access: <https://auth.nerdsbythehour.com/if/admin/>
 
 ### Step 1: Create Provider
 
@@ -73,6 +76,7 @@
 The ForwardAuth middleware has been created in the cluster. To protect a service:
 
 1. Add the middleware annotation to your Ingress:
+
    ```yaml
    annotations:
      traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
@@ -84,12 +88,12 @@ Other services in the cluster apply the Authentik ForwardAuth middleware directl
 
 Unprotected (accessible without login):
 
-- **Whoami**: https://nerdsbythehour.com and https://deby.nerdsbythehour.com
+- **Whoami**: <https://nerdsbythehour.com> and <https://deby.nerdsbythehour.com>
 
 ## Important URLs
 
-- **Authentik Setup**: https://auth.nerdsbythehour.com/if/flow/initial-setup/
-- **Authentik Admin Portal**: https://auth.nerdsbythehour.com/if/admin/
+- **Authentik Setup**: <https://auth.nerdsbythehour.com/if/flow/initial-setup/>
+- **Authentik Admin Portal**: <https://auth.nerdsbythehour.com/if/admin/>
 
 ## Default Credentials
 
@@ -98,6 +102,7 @@ Unprotected (accessible without login):
 ## DNS Configuration
 
 All DNS records are configured in Cloudflare with Proxy enabled (orange cloud):
+
 - auth.nerdsbythehour.com → Cloudflare Proxy → 174.105.183.192 → 192.168.68.71
 
 ## Troubleshooting
@@ -105,6 +110,7 @@ All DNS records are configured in Cloudflare with Proxy enabled (orange cloud):
 ### "Not Found" Error from Authentik
 
 If you see an Authentik-branded "Not Found" page when accessing a protected service:
+
 - ✅ **Good**: ForwardAuth middleware is working and intercepting requests
 - ❌ **Issue**: OAuth2/Proxy Provider configuration is incomplete or missing
 
@@ -113,6 +119,7 @@ If you see an Authentik-branded "Not Found" page when accessing a protected serv
 ### Version-Specific UI Differences
 
 You're running Authentik **2025.10.1**. The UI and options may differ from older guides:
+
 - Look for "Proxy" or "Forward auth" when creating providers
 - Some versions have "Forward auth (single application)" vs "Forward auth (domain level)"
 - Use "Forward auth (single application)" if available

--- a/apps/production/authentik/SECRET-MANAGEMENT.md
+++ b/apps/production/authentik/SECRET-MANAGEMENT.md
@@ -7,6 +7,7 @@ Authentik requires sensitive credentials that **must not** be stored in git. Thi
 ## Secrets Location
 
 Secrets are stored in a Kubernetes Secret named `authentik-secrets` in the `authentik` namespace. This secret is:
+
 - ✅ Created directly in the cluster
 - ✅ NOT stored in git
 - ✅ Referenced by the HelmRelease via `valuesFrom`
@@ -72,6 +73,7 @@ valuesFrom:
 ```
 
 This approach:
+
 - ✅ Keeps secrets out of git
 - ✅ Works with Flux/HelmRelease
 - ✅ Allows secret rotation without git commits
@@ -82,12 +84,14 @@ This approach:
 To rotate secrets:
 
 1. Generate new secrets:
+
    ```bash
    NEW_SECRET_KEY=$(openssl rand -base64 64 | tr -d '\n')
    NEW_DB_PASSWORD=$(openssl rand -base64 32 | tr -d '\n')
    ```
 
 2. Update the Kubernetes secret:
+
    ```bash
    kubectl create secret generic authentik-secrets \
      -n authentik \
@@ -97,6 +101,7 @@ To rotate secrets:
    ```
 
 3. Restart Authentik:
+
    ```bash
    kubectl rollout restart deployment -n authentik -l app.kubernetes.io/name=authentik
    ```
@@ -119,16 +124,19 @@ The `authentik-secrets` secret doesn't exist. Create it using the commands above
 ### Authentik fails to start after secret rotation
 
 1. Check the secret exists:
+
    ```bash
    kubectl get secret authentik-secrets -n authentik
    ```
 
 2. Verify secret contents (base64 encoded):
+
    ```bash
    kubectl get secret authentik-secrets -n authentik -o yaml
    ```
 
 3. Check HelmRelease logs:
+
    ```bash
    kubectl logs -n authentik -l app.kubernetes.io/name=authentik
    ```

--- a/apps/production/database/README.md
+++ b/apps/production/database/README.md
@@ -57,11 +57,13 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO teslamate;
 Applications connect using Kubernetes service DNS:
 
 **Connection String Format**:
+
 ```
 postgresql://username:password@postgresql.database.svc.cluster.local:5432/dbname
 ```
 
 **Example (TeslaMate)**:
+
 ```yaml
 env:
   - name: DATABASE_HOST
@@ -138,6 +140,7 @@ sudo kubectl exec -n database postgresql-0 -- psql -U postgres -c "SELECT datnam
 ## Scaling Considerations
 
 This is a single-instance PostgreSQL deployment. For high availability:
+
 - Consider PostgreSQL operators (e.g., CloudNativePG, Zalando Postgres Operator)
 - Implement automated backups
 - Set up replication
@@ -178,6 +181,7 @@ If the pod is deleted, data persists and will be reused when pod restarts.
 ### PostgreSQL Version Upgrades
 
 When upgrading PostgreSQL major versions:
+
 1. Backup all databases
 2. Use pg_upgrade or logical replication
 3. Test thoroughly before production cutover

--- a/apps/production/geohazardwatch/README.md
+++ b/apps/production/geohazardwatch/README.md
@@ -48,6 +48,7 @@ kubectl -n geohazardwatch create secret generic geohazardwatch-secrets \
 - The hostPath `/mnt/tank/jims/data/systems/geohazardwatch` is auto-created (`DirectoryOrCreate`). Confirm permissions allow uid/gid 1000 to write.
 - Default credentials `admin` / `admin123` — change immediately after first access.
 - Run an initial data import once before relying on the site:
+
   ```bash
   kubectl -n geohazardwatch create job --from=cronjob/geohazardwatch-data-refresh initial-import
   ```

--- a/apps/production/guest-services/README.md
+++ b/apps/production/guest-services/README.md
@@ -5,18 +5,20 @@ Public-facing services that don't require authentication.
 ## Services
 
 ### whoami
+
 Simple HTTP service that displays request information including IP address, headers, and connection details.
 
-- **URL**: https://deby.nerdsbythehour.com
+- **URL**: <https://deby.nerdsbythehour.com>
 - **Image**: traefik/whoami:latest
 - **Authentication**: None (public)
 - **Purpose**: Debugging and connection information display
 - **Security**: Runs as apps:apps (3003:3003)
 
 ### openspeedtest
+
 Self-hosted network speed testing tool for measuring upload and download speeds.
 
-- **URL**: https://nerdsbythehour.com/speed
+- **URL**: <https://nerdsbythehour.com/speed>
 - **Image**: Custom build from /opt/traefik/openspeedtest
 - **Authentication**: None (public)
 - **Purpose**: Network speed testing
@@ -50,6 +52,7 @@ When making changes to the OpenSpeedTest source or configuration:
 1. Rebuild the image
 2. Re-import to k3s
 3. Restart the deployment:
+
    ```bash
    sudo kubectl rollout restart deployment/openspeedtest -n guest-services
    ```

--- a/apps/production/home-assistant-proxy/AUTHENTIK-SETUP.md
+++ b/apps/production/home-assistant-proxy/AUTHENTIK-SETUP.md
@@ -5,18 +5,20 @@ This guide walks you through configuring Authentik to work with Home Assistant.
 ## Status
 
 ✅ **Technical Setup Complete**
+
 - Traefik ingress configured with ForwardAuth middleware
 - External service proxy configured (192.168.68.20:8123)
 - Let's Encrypt certificate issued
 
 ⏳ **Authentik Configuration Required**
+
 - Create Proxy Provider application in Authentik
 - Configure Home Assistant trusted proxies
 
 ## Step 1: Create Authentik Proxy Provider
 
 1. **Log into Authentik**
-   - URL: https://auth.nerdsbythehour.com
+   - URL: <https://auth.nerdsbythehour.com>
    - Login as administrator
 
 2. **Navigate to Applications**
@@ -66,12 +68,14 @@ Home Assistant needs to trust the reverse proxy headers from Traefik/Authentik.
 ### Edit configuration.yaml
 
 1. **SSH to Home Assistant host:**
+
    ```bash
    ssh 192.168.68.20
    # or access the Home Assistant terminal
    ```
 
 2. **Edit `/homeassistant/configuration.yaml`:**
+
    ```yaml
    http:
      use_x_forwarded_for: true
@@ -88,7 +92,7 @@ Home Assistant needs to trust the reverse proxy headers from Traefik/Authentik.
 ## Step 3: Test Access
 
 1. **Open browser in private/incognito mode**
-   - Navigate to: https://ha.nerdsbythehour.com
+   - Navigate to: <https://ha.nerdsbythehour.com>
 
 2. **Expected Flow:**
    - You should be redirected to Authentik login
@@ -109,9 +113,10 @@ By default, Home Assistant still requires its own authentication after passing t
 
 1. **Install the custom component:**
    - Add via HACS or manually install `hass-auth-header`
-   - Reference: https://github.com/BeryJu/hass-auth-header
+   - Reference: <https://github.com/BeryJu/hass-auth-header>
 
 2. **Configure in Home Assistant:**
+
    ```yaml
    # configuration.yaml
    auth_header:
@@ -152,6 +157,7 @@ curl -I -k https://ha.nerdsbythehour.com
 ```
 
 You should see headers like:
+
 ```
 x-authentik-id: <uuid>
 x-powered-by: authentik
@@ -164,6 +170,7 @@ sudo kubectl get certificate -n home-assistant-proxy
 ```
 
 Should show:
+
 ```
 NAME                  READY   SECRET               AGE
 home-assistant-cert   True    home-assistant-tls   1d
@@ -176,6 +183,7 @@ sudo kubectl get ingress -n home-assistant-proxy
 ```
 
 Should show:
+
 ```
 NAME             CLASS     HOSTS                   ADDRESS         PORTS
 home-assistant   traefik   ha.nerdsbythehour.com   192.168.68.71   80, 443
@@ -205,6 +213,6 @@ Traefik → home-assistant-external Service
 
 ## Related Documentation
 
-- Authentik Home Assistant Integration: https://integrations.goauthentik.io/miscellaneous/home-assistant/
-- Home Assistant HTTP Integration: https://www.home-assistant.io/integrations/http/
-- Traefik ForwardAuth: https://doc.traefik.io/traefik/middlewares/http/forwardauth/
+- Authentik Home Assistant Integration: <https://integrations.goauthentik.io/miscellaneous/home-assistant/>
+- Home Assistant HTTP Integration: <https://www.home-assistant.io/integrations/http/>
+- Traefik ForwardAuth: <https://doc.traefik.io/traefik/middlewares/http/forwardauth/>

--- a/apps/production/home-assistant-proxy/README.md
+++ b/apps/production/home-assistant-proxy/README.md
@@ -4,7 +4,7 @@ Proxy for external Home Assistant instance with Authentik authentication.
 
 ## Overview
 
-- **URL:** https://ha.nerdsbythehour.com
+- **URL:** <https://ha.nerdsbythehour.com>
 - **Backend:** 192.168.68.20:8123 (external host on local network)
 - **Type:** External Service Proxy (Home Assistant runs outside k3s)
 - **Security:** Protected by Authentik ForwardAuth (to be enabled)
@@ -74,7 +74,8 @@ curl -I https://ha.nerdsbythehour.com
 ### Architecture
 
 This setup uses Authentik as a forward authentication proxy:
-1. User requests https://ha.nerdsbythehour.com
+
+1. User requests <https://ha.nerdsbythehour.com>
 2. Traefik forwards authentication to Authentik
 3. If authenticated, Authentik passes request to Home Assistant with user headers
 4. Home Assistant trusts the headers from Authentik
@@ -85,7 +86,7 @@ This setup uses Authentik as a forward authentication proxy:
 
 Create a Proxy Provider application in Authentik:
 
-1. Log into Authentik at https://auth.nerdsbythehour.com
+1. Log into Authentik at <https://auth.nerdsbythehour.com>
 2. Navigate to **Applications > Applications**
 3. Click **Create with Provider**
 4. Select **Proxy** as provider type
@@ -102,6 +103,7 @@ Home Assistant needs to trust the proxy headers from Authentik:
 
 1. SSH to the Home Assistant host (192.168.68.20)
 2. Edit `/homeassistant/configuration.yaml`:
+
    ```yaml
    http:
      use_x_forwarded_for: true
@@ -110,6 +112,7 @@ Home Assistant needs to trust the proxy headers from Authentik:
        - 10.43.0.0/16  # k3s service network
        - 192.168.68.71 # k3s host (deby)
    ```
+
 3. Restart Home Assistant
 
 #### 3. (Optional) Install hass-auth-header Component
@@ -120,7 +123,7 @@ For automatic user matching based on Authentik username:
 2. Configure it to use `X-authentik-username` header
 3. Users will auto-login if their HA username matches Authentik username
 
-Reference: https://integrations.goauthentik.io/miscellaneous/home-assistant/
+Reference: <https://integrations.goauthentik.io/miscellaneous/home-assistant/>
 
 **Important:** Home Assistant will still require its own user accounts. Authentik provides SSO layer, but users must exist in HA.
 
@@ -137,6 +140,7 @@ This directory contains the Home Assistant configuration files that sync to the 
 ### 502 Bad Gateway
 
 Check if Home Assistant is running on the backend:
+
 ```bash
 curl -I https://192.168.68.20:8123 -k
 ```
@@ -144,6 +148,7 @@ curl -I https://192.168.68.20:8123 -k
 ### Certificate Issues
 
 Check cert-manager:
+
 ```bash
 kubectl describe certificate -n home-assistant-proxy
 kubectl get certificaterequest -n home-assistant-proxy
@@ -152,6 +157,7 @@ kubectl get certificaterequest -n home-assistant-proxy
 ### DNS Not Resolving
 
 Verify DNS:
+
 ```bash
 nslookup ha.nerdsbythehour.com
 # Should resolve to your public IP
@@ -160,6 +166,7 @@ nslookup ha.nerdsbythehour.com
 ### Authentik 401 Errors
 
 Check Authentik configuration:
+
 ```bash
 kubectl logs -n authentik -l app.kubernetes.io/name=authentik
 ```

--- a/apps/production/jimsmcp/README.md
+++ b/apps/production/jimsmcp/README.md
@@ -18,16 +18,19 @@ jimsmcp complements the official Kubernetes MCP server with custom features spec
 ## Features
 
 ### Flux GitOps
+
 - **flux_get_status** - Check status of all Flux resources
 - **flux_reconcile** - Force reconciliation of kustomizations, helm releases, or git repositories
 
 ### Application Management
+
 - **app_health_check** - Comprehensive health check for a specific app (pods + service + ingress)
 - **app_health_check_all** - Check health of all applications in the cluster (auto-discovers via ingresses)
 - **app_get_urls** - List all application URLs and ingress endpoints
 - **authentik_get_info** - Get Authentik API and admin URLs
 
 ### Authentik Management
+
 - **authentik_create_homeassistant_app** - Create complete Home Assistant Authentik setup
 - **authentik_list_applications** - List all Authentik applications
 - **authentik_list_providers** - List all Authentik providers
@@ -35,6 +38,7 @@ jimsmcp complements the official Kubernetes MCP server with custom features spec
 - **authentik_bind_provider_to_outpost** - Bind a provider to an outpost (enables ForwardAuth)
 
 ### Financial Data
+
 - **stocks_get_price** - Get real-time stock quotes from Alpha Vantage (requires API key)
 
 ## Installation
@@ -96,12 +100,14 @@ Configure both the official Kubernetes MCP server and jimsmcp in your Claude Cod
 ## Tool Examples
 
 ### Check health of all applications
+
 ```typescript
 // Using app_health_check_all
 // Returns status of all ingress-exposed apps with pod/service/ingress details
 ```
 
 ### Check specific app health
+
 ```typescript
 // Using app_health_check
 {
@@ -111,6 +117,7 @@ Configure both the official Kubernetes MCP server and jimsmcp in your Claude Cod
 ```
 
 ### Get Flux status
+
 ```typescript
 // Using flux_get_status
 {
@@ -119,6 +126,7 @@ Configure both the official Kubernetes MCP server and jimsmcp in your Claude Cod
 ```
 
 ### Reconcile Flux resources
+
 ```typescript
 // Using flux_reconcile
 {
@@ -129,6 +137,7 @@ Configure both the official Kubernetes MCP server and jimsmcp in your Claude Cod
 ```
 
 ### Get all application URLs
+
 ```typescript
 // Using app_get_urls
 {
@@ -146,6 +155,7 @@ jimsmcp runs as a standalone Node.js process that:
 4. Communicates via stdio using the MCP protocol
 
 **Separation of Concerns:**
+
 - **Kubernetes MCP Server**: Handles standard K8s queries and operations
 - **jimsmcp**: Handles infrastructure-specific features (Flux, Authentik, custom health checks)
 
@@ -160,6 +170,7 @@ jimsmcp runs as a standalone Node.js process that:
 ## Security
 
 jimsmcp inherits permissions from your kubeconfig. It can:
+
 - Read Kubernetes resources (via kubernetes MCP server)
 - View logs (via kubernetes MCP server)
 - Trigger Flux reconciliations
@@ -167,6 +178,7 @@ jimsmcp inherits permissions from your kubeconfig. It can:
 - Trigger infrastructure workflows
 
 It CANNOT:
+
 - Modify or delete resources (read-only by design)
 - Execute commands in pods
 - Change cluster configuration
@@ -175,6 +187,7 @@ It CANNOT:
 ## Kubernetes Deployment (Future)
 
 While jimsmcp currently runs locally, it can be deployed as a Kubernetes service with:
+
 - API server for HTTP-based MCP communication
 - ServiceAccount with RBAC for cluster access
 - Ingress for external access (with Authentik protection)
@@ -182,16 +195,21 @@ While jimsmcp currently runs locally, it can be deployed as a Kubernetes service
 ## Troubleshooting
 
 ### "Unable to connect to cluster"
+
 Ensure kubectl is working: `kubectl get nodes`
 
 ### "Flux command not found"
-Install flux CLI: https://fluxcd.io/flux/installation/
+
+Install flux CLI: <https://fluxcd.io/flux/installation/>
 
 ### "Permission denied"
+
 Check your kubeconfig has the necessary RBAC permissions
 
 ### Using both MCP servers
+
 If you get errors about unknown tools:
+
 - Standard K8s operations (pods, deployments, services, logs) → use `kubernetes` MCP server
 - Custom infrastructure features (Flux, Authentik, health checks) → use `jimsmcp` MCP server
 

--- a/apps/production/jimsmcp/SETUP.md
+++ b/apps/production/jimsmcp/SETUP.md
@@ -22,6 +22,7 @@ Add jimsmcp to your Claude Code MCP configuration:
 ```
 
 Or copy the example config:
+
 ```bash
 mkdir -p ~/.config/claude-code
 cp /home/jim/Documents/mj-infra-flux/apps/production/jimsmcp/mcp-config-example.json ~/.config/claude-code/mcp.json
@@ -50,6 +51,7 @@ Or:
 jimsmcp provides 10 tools for managing your infrastructure:
 
 ### Kubernetes Management (5 tools)
+
 - `mcp__jimsmcp__k8s_get_pods` - List pods with status
 - `mcp__jimsmcp__k8s_get_pod_logs` - Get pod logs
 - `mcp__jimsmcp__k8s_get_deployments` - View deployments
@@ -57,10 +59,12 @@ jimsmcp provides 10 tools for managing your infrastructure:
 - `mcp__jimsmcp__k8s_get_ingresses` - View ingresses
 
 ### Flux GitOps (2 tools)
+
 - `mcp__jimsmcp__flux_get_status` - Check Flux resource status
 - `mcp__jimsmcp__flux_reconcile` - Force reconciliation
 
 ### Application Management (3 tools)
+
 - `mcp__jimsmcp__app_health_check` - Comprehensive health check
 - `mcp__jimsmcp__app_get_urls` - List all application URLs
 - `mcp__jimsmcp__authentik_get_info` - Get Authentik info
@@ -88,6 +92,7 @@ npm run build
 ```
 
 For development with auto-rebuild:
+
 ```bash
 npm run watch
 ```
@@ -95,25 +100,32 @@ npm run watch
 ## Troubleshooting
 
 ### "Cannot find module"
+
 Make sure dependencies are installed:
+
 ```bash
 cd /home/jim/Documents/mj-infra-flux/apps/production/jimsmcp
 npm install
 ```
 
 ### "Unable to connect to cluster"
+
 jimsmcp uses your default kubeconfig. Verify kubectl works:
+
 ```bash
 kubectl get nodes
 ```
 
 ### "Flux command not found"
+
 Ensure flux CLI is installed and in PATH:
+
 ```bash
 flux version
 ```
 
 ### Claude Code doesn't see the tools
+
 1. Check that `~/.config/claude-code/mcp.json` exists and has the correct path
 2. Restart Claude Code completely
 3. Check Claude Code logs for MCP connection errors
@@ -121,6 +133,7 @@ flux version
 ## Security Notes
 
 jimsmcp runs with the same permissions as your kubectl/kubeconfig. It can:
+
 - ✅ Read all cluster resources
 - ✅ View logs
 - ✅ Trigger Flux reconciliations

--- a/apps/production/jimsmcp/TOOLS.md
+++ b/apps/production/jimsmcp/TOOLS.md
@@ -9,10 +9,12 @@ Complete reference for all 14 tools provided by jimsmcp.
 Get pods in a namespace or across all namespaces.
 
 **Parameters:**
+
 - `namespace` (optional): Namespace to query
 - `labelSelector` (optional): Label selector (e.g., 'app=grafana')
 
 **Examples:**
+
 ```json
 // All pods in monitoring namespace
 {"namespace": "monitoring"}
@@ -25,6 +27,7 @@ Get pods in a namespace or across all namespaces.
 ```
 
 **Returns:**
+
 ```json
 [
   {
@@ -45,12 +48,14 @@ Get pods in a namespace or across all namespaces.
 Get logs from a specific pod.
 
 **Parameters:**
+
 - `namespace` (required): Namespace of the pod
 - `podName` (required): Name of the pod
 - `container` (optional): Container name
 - `tailLines` (optional): Number of lines to tail (default: 100)
 
 **Example:**
+
 ```json
 {
   "namespace": "monitoring",
@@ -66,9 +71,11 @@ Get logs from a specific pod.
 Get deployments in a namespace or across all namespaces.
 
 **Parameters:**
+
 - `namespace` (optional): Namespace to query
 
 **Returns:**
+
 ```json
 [
   {
@@ -89,9 +96,11 @@ Get deployments in a namespace or across all namespaces.
 Get services in a namespace or across all namespaces.
 
 **Parameters:**
+
 - `namespace` (optional): Namespace to query
 
 **Returns:**
+
 ```json
 [
   {
@@ -117,9 +126,11 @@ Get services in a namespace or across all namespaces.
 Get ingresses in a namespace or across all namespaces.
 
 **Parameters:**
+
 - `namespace` (optional): Namespace to query
 
 **Returns:**
+
 ```json
 [
   {
@@ -145,10 +156,12 @@ Get ingresses in a namespace or across all namespaces.
 Get status of all Flux resources or specific kustomizations.
 
 **Parameters:**
+
 - `resource` (optional): Specific resource type ('kustomization', 'helmrelease')
 - `namespace` (optional): Namespace to query (default: flux-system)
 
 **Examples:**
+
 ```json
 // All Flux resources
 {}
@@ -169,12 +182,14 @@ Get status of all Flux resources or specific kustomizations.
 Force reconciliation of a Flux resource.
 
 **Parameters:**
+
 - `kind` (required): 'kustomization', 'helmrelease', or 'gitrepository'
 - `name` (required): Name of the resource
 - `namespace` (optional): Namespace (default: flux-system)
 - `withSource` (optional): Also reconcile source (default: false)
 
 **Example:**
+
 ```json
 {
   "kind": "kustomization",
@@ -192,10 +207,12 @@ Force reconciliation of a Flux resource.
 Comprehensive health check for an application (pods + service + ingress).
 
 **Parameters:**
+
 - `app` (required): Application name
 - `namespace` (required): Namespace
 
 **Example:**
+
 ```json
 {
   "app": "grafana",
@@ -204,6 +221,7 @@ Comprehensive health check for an application (pods + service + ingress).
 ```
 
 **Returns:**
+
 ```json
 {
   "app": "grafana",
@@ -235,9 +253,11 @@ Comprehensive health check for an application (pods + service + ingress).
 Get all URLs/ingresses for applications in the cluster.
 
 **Parameters:**
+
 - `namespace` (optional): Filter by namespace
 
 **Returns:**
+
 ```json
 [
   {
@@ -264,6 +284,7 @@ Get information about Authentik deployment and API endpoint.
 **Parameters:** None
 
 **Returns:**
+
 ```json
 {
   "namespace": "authentik",
@@ -290,6 +311,7 @@ Create a complete Authentik setup for Home Assistant (proxy provider + applicati
 **Parameters:** None (uses hardcoded configuration for ha.nerdsbythehour.com)
 
 **What it does:**
+
 1. Creates a Proxy Provider with:
    - External host: `https://ha.nerdsbythehour.com`
    - Internal host: `https://192.168.68.20:8123`
@@ -299,6 +321,7 @@ Create a complete Authentik setup for Home Assistant (proxy provider + applicati
 3. Returns URLs for admin configuration
 
 **Returns:**
+
 ```json
 {
   "provider": {
@@ -319,6 +342,7 @@ Create a complete Authentik setup for Home Assistant (proxy provider + applicati
 ```
 
 **Example:**
+
 ```json
 {}
 ```
@@ -332,6 +356,7 @@ List all applications configured in Authentik.
 **Parameters:** None
 
 **Returns:**
+
 ```json
 [
   {
@@ -353,6 +378,7 @@ List all providers configured in Authentik.
 **Parameters:** None
 
 **Returns:**
+
 ```json
 [
   {
@@ -428,13 +454,13 @@ cd /home/jim/Documents/mj-infra-flux/apps/production/jimsmcp
 echo "ALPHA_VANTAGE_KEY=your_api_key_here" > .env.secret.stocks
 ```
 
-2. Encrypt it with SOPS:
+1. Encrypt it with SOPS:
 
 ```bash
 ./scripts/encrypt-env-files.sh apps/production/jimsmcp/
 ```
 
-3. Load the environment before running jimsmcp:
+1. Load the environment before running jimsmcp:
 
 ```bash
 export ALPHA_VANTAGE_KEY=$(cat .env.secret.stocks)

--- a/apps/production/landingpage/README.md
+++ b/apps/production/landingpage/README.md
@@ -5,6 +5,7 @@ Main landing page for nerdsbythehour.com built with React and Vite.
 ## Overview
 
 The landing page serves three main routes:
+
 - `/` - Public landing page
 - `/guest` - Guest access page with links to:
   - OpenSpeedTest at `/speed`
@@ -18,22 +19,26 @@ The landing page serves three main routes:
 ### Build and Deploy Process
 
 1. **Build the Docker image** (from `/opt/traefik/landingpage`):
+
    ```bash
    cd /opt/traefik/landingpage
    docker build -t landingpage:latest .
    ```
 
 2. **Export the image for k3s**:
+
    ```bash
    docker save landingpage:latest -o /tmp/landingpage.tar
    ```
 
 3. **Import into k3s**:
+
    ```bash
    sudo k3s ctr images import /tmp/landingpage.tar
    ```
 
 4. **Apply with Flux** (or kubectl):
+
    ```bash
    # Flux will automatically pick up changes from git
    # Or manually apply:
@@ -47,6 +52,7 @@ When you make changes to the React source code:
 1. Rebuild the Docker image with a new tag or updated content
 2. Re-export and re-import to k3s
 3. Restart the deployment:
+
    ```bash
    sudo kubectl rollout restart deployment/landingpage -n landingpage
    ```
@@ -68,6 +74,7 @@ When you make changes to the React source code:
 The `/members` route uses a Traefik middleware to redirect users directly to the Authentik User Library at `https://auth.nerdsbythehour.com/if/user/#/library`. This eliminates the need for a separate Members page since Authentik already provides a user portal showing all authorized applications.
 
 **Implementation**:
+
 - `middleware-redirect-members.yaml` - Traefik redirectRegex middleware
 - Permanent (301) redirect to Authentik library
 - Users authenticate at Authentik and see their application library
@@ -82,6 +89,7 @@ The `/members` route uses a Traefik middleware to redirect users directly to the
 ## Monitoring
 
 Health checks:
+
 - Liveness probe: HTTP GET `/` every 30s
 - Readiness probe: HTTP GET `/` every 10s
 
@@ -89,7 +97,8 @@ Health checks:
 
 The React application source is located at `/opt/traefik/landingpage/` on the host.
 
-### Key Files:
+### Key Files
+
 - `src/App.tsx` - React Router configuration
 - `src/pages/LandingPage.tsx` - Main landing page
 - `src/pages/GuestPage.tsx` - Guest access page

--- a/apps/production/messaging/README.md
+++ b/apps/production/messaging/README.md
@@ -27,6 +27,7 @@ Each application uses its own topic prefix for isolation:
 Applications connect using Kubernetes service DNS:
 
 **Connection Example (TeslaMate)**:
+
 ```yaml
 env:
   - name: MQTT_HOST
@@ -36,6 +37,7 @@ env:
 ```
 
 **Connection Example (Python)**:
+
 ```python
 import paho.mqtt.client as mqtt
 
@@ -82,6 +84,7 @@ sudo kubectl run -it --rm mqtt-debug --image=eclipse-mosquitto:2 --restart=Never
 The Mosquitto configuration is managed via ConfigMap (`mosquitto-configmap.yaml`).
 
 Current settings:
+
 - **Persistence**: Enabled (messages persisted to disk)
 - **Authentication**: Anonymous allowed (internal cluster only)
 - **Listeners**: 1883 (MQTT)
@@ -96,11 +99,13 @@ Current settings:
 ## Security Notes
 
 ### Current Setup (Internal Only)
+
 - **No authentication**: Safe for internal cluster communication
 - **No TLS**: Not exposed outside cluster
 - **Topic isolation**: Applications use prefixed topics
 
 ### Future Enhancements (If Exposing Externally)
+
 - Add username/password authentication
 - Enable TLS/SSL
 - Use Network Policies for pod-level access control
@@ -109,6 +114,7 @@ Current settings:
 ## Data Persistence
 
 Message persistence is stored at:
+
 ```
 /mnt/local-k3s-data/mosquitto/data/
 ```
@@ -131,6 +137,7 @@ The host-level `backup-deby.sh` already covers `/mnt/local-k3s-data/` as part of
 ### Connection Refused
 
 Check that the service is running:
+
 ```bash
 sudo kubectl get svc -n messaging
 sudo kubectl get endpoints -n messaging mosquitto
@@ -139,11 +146,13 @@ sudo kubectl get endpoints -n messaging mosquitto
 ### Messages Not Persisting
 
 Check PVC is bound:
+
 ```bash
 sudo kubectl get pvc -n messaging
 ```
 
 Check logs for errors:
+
 ```bash
 sudo kubectl logs -n messaging -l app=mosquitto --tail=50
 ```
@@ -151,6 +160,7 @@ sudo kubectl logs -n messaging -l app=mosquitto --tail=50
 ### High Memory Usage
 
 Adjust retain limits in ConfigMap if needed:
+
 ```conf
 max_queued_messages 1000
 max_inflight_messages 20
@@ -192,17 +202,20 @@ sudo kubectl apply -k apps/production/messaging/
 ## Use Cases
 
 ### TeslaMate Telemetry
+
 - Real-time vehicle state updates
 - Location tracking
 - Charging status
 - Climate control state
 
 ### Home Assistant (Future)
+
 - Smart home device state
 - Automation triggers
 - Sensor readings
 
 ### Custom IoT Projects
+
 - Weather stations
 - Custom sensors
 - Integration bridges

--- a/apps/production/monitoring/GRAFANA-TESLAMATE-SETUP.md
+++ b/apps/production/monitoring/GRAFANA-TESLAMATE-SETUP.md
@@ -4,13 +4,13 @@ This guide walks through configuring Grafana to visualize TeslaMate data.
 
 ## Prerequisites
 
-- Grafana deployed and accessible at https://grafana.nerdsbythehour.com
+- Grafana deployed and accessible at <https://grafana.nerdsbythehour.com>
 - TeslaMate deployed with data in shared PostgreSQL
 - PostgreSQL database `teslamate` with data migrated
 
 ## Step 1: Access Grafana
 
-1. Open https://grafana.nerdsbythehour.com
+1. Open <https://grafana.nerdsbythehour.com>
 2. Default credentials:
    - Username: `admin`
    - Password: `admin` (you'll be prompted to change this)
@@ -47,29 +47,30 @@ TeslaMate provides pre-built dashboards. You can import them individually or use
 2. Import each dashboard from the official TeslaMate repository:
 
 **Available Dashboards**:
-- **Overview**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/overview.json
-- **Drives**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/drives.json
-- **Charges**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/charges.json
-- **Charging Stats**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/charging-stats.json
-- **Charge Level**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/charge-level.json
-- **Battery Health**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/battery-health.json
-- **Drive Stats**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/drive-stats.json
-- **Updates**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/updates.json
-- **Efficiency**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/efficiency.json
-- **Vampire Drain**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/vampire-drain.json
-- **Visited**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/visited.json
-- **Drive Details**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/drive-details.json
-- **Charge Details**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/charge-details.json
-- **Projected Range**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/projected-range.json
-- **States**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/states.json
-- **Trip**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/trip.json
-- **Timeline**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/timeline.json
-- **Locations**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/locations.json
-- **Degradation**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/degradation.json
-- **Drive Mileage**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/mileage.json
-- **Database Info**: https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/database-info.json
 
-3. For each dashboard:
+- **Overview**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/overview.json>
+- **Drives**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/drives.json>
+- **Charges**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/charges.json>
+- **Charging Stats**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/charging-stats.json>
+- **Charge Level**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/charge-level.json>
+- **Battery Health**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/battery-health.json>
+- **Drive Stats**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/drive-stats.json>
+- **Updates**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/updates.json>
+- **Efficiency**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/efficiency.json>
+- **Vampire Drain**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/vampire-drain.json>
+- **Visited**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/visited.json>
+- **Drive Details**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/drive-details.json>
+- **Charge Details**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/charge-details.json>
+- **Projected Range**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/projected-range.json>
+- **States**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/states.json>
+- **Trip**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/trip.json>
+- **Timeline**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/timeline.json>
+- **Locations**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/locations.json>
+- **Degradation**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/degradation.json>
+- **Drive Mileage**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/mileage.json>
+- **Database Info**: <https://raw.githubusercontent.com/teslamate-org/teslamate/main/grafana/dashboards/database-info.json>
+
+1. For each dashboard:
    - Paste the URL in the "Import via grafana.com" field
    - Click **Load**
    - Select the **TeslaMate** data source you created
@@ -103,7 +104,7 @@ This allows TeslaMate to provide direct links to relevant Grafana dashboards.
 
 ## Step 5: Verify Everything Works
 
-1. Access TeslaMate: https://teslamate.nerdsbythehour.com
+1. Access TeslaMate: <https://teslamate.nerdsbythehour.com>
 2. Sign in with your Tesla credentials
 3. Once vehicles are logging data, check Grafana dashboards
 4. Recommended starting dashboards:
@@ -132,6 +133,7 @@ If dashboards show data from before the migration, it worked! 🎉
 **Error**: "dial tcp: lookup postgresql.database.svc.cluster.local"
 
 **Solution**: Ensure PostgreSQL service exists and is running:
+
 ```bash
 sudo kubectl get svc -n database postgresql
 sudo kubectl get pods -n database
@@ -140,11 +142,12 @@ sudo kubectl get pods -n database
 ### No Data in Dashboards
 
 1. **Check TeslaMate is signed in**:
-   - Visit https://teslamate.nerdsbythehour.com
+   - Visit <https://teslamate.nerdsbythehour.com>
    - Sign in with Tesla credentials
    - Verify vehicles appear and are logging
 
 2. **Check data exists in database**:
+
    ```bash
    sudo kubectl exec -n database postgresql-0 -- psql -U teslamate -d teslamate -c \
      "SELECT COUNT(*) FROM positions;"
@@ -170,11 +173,14 @@ Or re-import the dashboard and select the correct data source.
 
 1. **Change Grafana admin password** immediately after first login
 2. **Restrict Grafana access** with Authentik ForwardAuth:
+
    ```yaml
    # In grafana-ingress.yaml, uncomment:
    traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
    ```
+
 3. **Change PostgreSQL password**:
+
    ```bash
    # Update teslamate-secret.yaml with new password
    kubectl edit secret teslamate-secret -n teslamate
@@ -192,6 +198,6 @@ Or re-import the dashboard and select the correct data source.
 
 ## Resources
 
-- TeslaMate Dashboard Gallery: https://docs.teslamate.org/docs/guides/dashboards
-- Grafana Documentation: https://grafana.com/docs/grafana/latest/
-- PostgreSQL Data Source: https://grafana.com/docs/grafana/latest/datasources/postgres/
+- TeslaMate Dashboard Gallery: <https://docs.teslamate.org/docs/guides/dashboards>
+- Grafana Documentation: <https://grafana.com/docs/grafana/latest/>
+- PostgreSQL Data Source: <https://grafana.com/docs/grafana/latest/datasources/postgres/>

--- a/apps/production/monitoring/README.md
+++ b/apps/production/monitoring/README.md
@@ -5,8 +5,8 @@ Comprehensive monitoring solution for the k3s cluster with metrics collection, s
 ## Overview
 
 - **Namespace**: `monitoring`
-- **Prometheus URL**: https://prometheus.nerdsbythehour.com (with basic auth)
-- **Grafana URL**: https://grafana.nerdsbythehour.com
+- **Prometheus URL**: <https://prometheus.nerdsbythehour.com> (with basic auth)
+- **Grafana URL**: <https://grafana.nerdsbythehour.com>
 - **Components**:
   - Prometheus - Metrics collection and storage
   - Grafana - Visualization and dashboards
@@ -40,6 +40,7 @@ Comprehensive monitoring solution for the k3s cluster with metrics collection, s
 ## Deployed Components
 
 ### Prometheus
+
 - **Version**: 3.0.1
 - **Service**: `prometheus-service.monitoring.svc.cluster.local:80`
 - **Storage**: PVC `prometheus-storage-volume-prometheus-0` (60Gi, local-path provisioner); mounted at `/prometheus` in the pod
@@ -53,6 +54,7 @@ Comprehensive monitoring solution for the k3s cluster with metrics collection, s
   - Alert rules
 
 ### Grafana
+
 - **Version**: 10.1.6
 - **Service**: `grafana-service.monitoring.svc.cluster.local:80`
 - **Storage**: `/mnt/local-k3s-data/grafana`
@@ -65,6 +67,7 @@ Comprehensive monitoring solution for the k3s cluster with metrics collection, s
   - Alert visualization
 
 ### Alertmanager
+
 - **Version**: Latest
 - **Service**: `alertmanager.monitoring.svc.cluster.local:9093`
 - **Purpose**: Routes and manages alerts from Prometheus
@@ -74,28 +77,30 @@ Comprehensive monitoring solution for the k3s cluster with metrics collection, s
   - Notification routing (email, Slack, webhook)
 
 ### Blackbox Exporter
+
 - **Version**: 0.25.0
 - **Service**: `blackbox-exporter.monitoring.svc.cluster.local:9115`
 - **DNS**: Uses local DNS (192.168.68.1) for external domain resolution
 - **Purpose**: Probes external HTTP/HTTPS endpoints
 - **Monitored Services**:
-  - https://nerdsbythehour.com (landing page)
-  - https://auth.nerdsbythehour.com (Authentik SSO)
-  - https://teslamate.nerdsbythehour.com
-  - https://grafana.nerdsbythehour.com
-  - https://ha.nerdsbythehour.com (Home Assistant)
-  - https://cdn.nerdsbythehour.com
+  - <https://nerdsbythehour.com> (landing page)
+  - <https://auth.nerdsbythehour.com> (Authentik SSO)
+  - <https://teslamate.nerdsbythehour.com>
+  - <https://grafana.nerdsbythehour.com>
+  - <https://ha.nerdsbythehour.com> (Home Assistant)
+  - <https://cdn.nerdsbythehour.com>
 - **Excluded**: traefik (internal), jimsmcp (internal), amd (known broken)
 
 ## Checking Service Health Probes
 
 ### Web UI
 
-- **https://prometheus.nerdsbythehour.com/alerts** - View all alert rules and current state (firing/pending/inactive)
-- **https://prometheus.nerdsbythehour.com/targets** - View all scrape targets including blackbox probes
-- **https://prometheus.nerdsbythehour.com/graph** - Query metrics directly with PromQL
+- **<https://prometheus.nerdsbythehour.com/alerts>** - View all alert rules and current state (firing/pending/inactive)
+- **<https://prometheus.nerdsbythehour.com/targets>** - View all scrape targets including blackbox probes
+- **<https://prometheus.nerdsbythehour.com/graph>** - Query metrics directly with PromQL
 
 **Alertmanager UI** (cluster internal):
+
 ```bash
 kubectl port-forward -n monitoring svc/alertmanager 9093:9093
 # Then browse to http://localhost:9093
@@ -166,13 +171,13 @@ kubectl exec -n monitoring deploy/blackbox-exporter -- wget -qO- \
 
 ### Access Grafana
 
-1. Navigate to: https://grafana.nerdsbythehour.com
+1. Navigate to: <https://grafana.nerdsbythehour.com>
 2. Login with admin credentials (check Grafana data directory or reset password)
 3. Prometheus datasource is already configured and set as default
 
 ### View Prometheus Metrics
 
-1. Navigate to: https://prometheus.nerdsbythehour.com
+1. Navigate to: <https://prometheus.nerdsbythehour.com>
 2. Enter credentials from web.yaml basic auth
 3. Explore metrics, run PromQL queries
 
@@ -195,6 +200,7 @@ Dashboard ID: 893
 ```
 
 **To import:**
+
 1. Grafana → Dashboards → Import
 2. Enter dashboard ID
 3. Select "Prometheus" as data source
@@ -207,6 +213,7 @@ Dashboard ID: 893
 Located in: `apps/production/monitoring/prometheus/config/`
 
 **Current scrape configs:**
+
 - `scrape-configs.prometheus.yaml` - Prometheus self-monitoring
 - `scrape-configs.coinpoet.yaml` - Custom application scraping
 - Kubernetes service discovery (built-in)
@@ -224,6 +231,7 @@ metadata:
 ```
 
 **Example:**
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -246,6 +254,7 @@ spec:
 ### Grafana Datasource
 
 Pre-configured via provisioning at:
+
 - `apps/production/monitoring/grafana/config/provisioning/datasources/prometheus.yaml`
 
 ```yaml
@@ -263,6 +272,7 @@ datasources:
 Instrument your application to expose Prometheus metrics:
 
 **Go (with prometheus/client_golang):**
+
 ```go
 import "github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -270,6 +280,7 @@ http.Handle("/metrics", promhttp.Handler())
 ```
 
 **Python (with prometheus-client):**
+
 ```python
 from prometheus_client import start_http_server, Counter
 
@@ -279,6 +290,7 @@ start_http_server(8080)  # Exposes /metrics on port 8080
 ```
 
 **Node.js (with prom-client):**
+
 ```javascript
 const client = require('prom-client');
 const register = new client.Registry();
@@ -296,18 +308,21 @@ Then add the annotation to your deployment as shown above.
 Install exporters for services that don't natively expose metrics:
 
 **PostgreSQL Exporter:**
+
 ```bash
 # Deploy postgres_exporter as a sidecar or separate deployment
 # Configure to connect to postgresql.database.svc.cluster.local
 ```
 
 **MQTT Exporter:**
+
 ```bash
 # Deploy mosquitto_exporter
 # Configure to connect to mosquitto.messaging.svc.cluster.local
 ```
 
 **Node Exporter (System Metrics):**
+
 ```bash
 # Deploy node-exporter as DaemonSet
 # Scrapes CPU, memory, disk, network from nodes
@@ -361,6 +376,7 @@ histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))
 Located in: `apps/production/monitoring/prometheus/config/`
 
 **Active alert rule files:**
+
 - `alerting-rules.prometheus.yaml` - Prometheus TSDB health (WAL, compaction, restarts, memory)
 - `alerting-rules.service-health.yaml` - Service failure alerts (added 2026-01-22)
 
@@ -394,15 +410,18 @@ Located in: `apps/production/monitoring/prometheus/config/`
 ### Alertmanager Configuration
 
 Configure notification routing in:
+
 - `apps/production/monitoring/prometheus-alertmanager/config/alertmanager.yaml`
 
 **Current configuration:**
+
 - **Receiver**: Telegram (chat_id: 510755639)
 - **Group wait**: 30s
 - **Group interval**: 5m
 - **Repeat interval**: 4h
 
 **Supported receivers:**
+
 - Email (SMTP)
 - Slack webhooks
 - PagerDuty
@@ -440,7 +459,7 @@ groups:
 
 ### 4. Monitor the Monitor
 
-- Check Prometheus targets: https://prometheus.nerdsbythehour.com/targets
+- Check Prometheus targets: <https://prometheus.nerdsbythehour.com/targets>
 - Check Grafana datasource health
 - Monitor Prometheus disk usage
 
@@ -505,12 +524,15 @@ curl -X POST https://prometheus.nerdsbythehour.com/-/reload
 
 ### Prometheus Not Scraping Targets
 
-1. Check target status: https://prometheus.nerdsbythehour.com/targets
+1. Check target status: <https://prometheus.nerdsbythehour.com/targets>
 2. Verify pod annotations:
+
    ```bash
    sudo kubectl get pod <pod-name> -o yaml | grep prometheus
    ```
+
 3. Check Prometheus logs:
+
    ```bash
    sudo kubectl logs -n monitoring prometheus-0 | grep -i error
    ```
@@ -518,18 +540,21 @@ curl -X POST https://prometheus.nerdsbythehour.com/-/reload
 ### Grafana Can't Connect to Prometheus
 
 1. Verify datasource config:
+
    ```bash
    sudo kubectl exec -n monitoring grafana-0 -- \
      cat /etc/grafana/provisioning/datasources/prometheus.yaml
    ```
 
 2. Test connectivity from Grafana:
+
    ```bash
    sudo kubectl exec -n monitoring grafana-0 -- \
      wget -qO- http://prometheus-service.monitoring.svc.cluster.local:80/-/healthy
    ```
 
 3. Check Grafana logs:
+
    ```bash
    sudo kubectl logs -n monitoring grafana-0 | grep -i prometheus
    ```
@@ -537,15 +562,18 @@ curl -X POST https://prometheus.nerdsbythehour.com/-/reload
 ### High Memory Usage
 
 Prometheus memory usage grows with:
+
 - Number of time series
 - Scrape frequency
 - Retention period
 
 **Solutions:**
+
 - Reduce retention time (default: 30d)
 - Reduce scrape frequency
 - Use recording rules
 - Drop unnecessary metrics:
+
   ```yaml
   metric_relabel_configs:
     - source_labels: [__name__]
@@ -569,11 +597,13 @@ sudo kubectl exec -n monitoring prometheus-0 -- \
 ### TeslaMate
 
 TeslaMate has built-in Prometheus metrics at `:4000/metrics`:
+
 - Vehicle state updates
 - API call rates
 - Database connection pool
 
 **Enable scraping:**
+
 ```yaml
 # In apps/production/teslamate/teslamate-deployment.yaml
 annotations:
@@ -584,6 +614,7 @@ annotations:
 ### PostgreSQL
 
 Deploy postgres_exporter to monitor:
+
 - Connection count
 - Query performance
 - Lock statistics
@@ -592,6 +623,7 @@ Deploy postgres_exporter to monitor:
 ### Authentik
 
 Authentik exposes metrics at `:9300/metrics`:
+
 - Login attempts
 - Active sessions
 - Token generation
@@ -599,32 +631,36 @@ Authentik exposes metrics at `:9300/metrics`:
 
 ## Resources
 
-- Prometheus docs: https://prometheus.io/docs/
-- Grafana docs: https://grafana.com/docs/grafana/latest/
-- PromQL guide: https://prometheus.io/docs/prometheus/latest/querying/basics/
-- Grafana dashboards: https://grafana.com/grafana/dashboards/
-- Kubernetes monitoring: https://github.com/prometheus-operator/kube-prometheus
+- Prometheus docs: <https://prometheus.io/docs/>
+- Grafana docs: <https://grafana.com/docs/grafana/latest/>
+- PromQL guide: <https://prometheus.io/docs/prometheus/latest/querying/basics/>
+- Grafana dashboards: <https://grafana.com/grafana/dashboards/>
+- Kubernetes monitoring: <https://github.com/prometheus-operator/kube-prometheus>
 
 ## TODO / Future Improvements
 
 ### High Priority
+
 - [ ] Add Grafana dashboard for service health probes
 - [ ] Configure alert silencing for maintenance windows
 - [ ] Add PostgreSQL exporter for detailed database metrics
 
 ### Medium Priority
+
 - [ ] Add Node Exporter dashboard to Grafana
 - [ ] Configure alert escalation (critical → page, warning → email)
 - [ ] Add MQTT broker health monitoring
 - [ ] Monitor Authentik login success/failure rates
 
 ### Low Priority
+
 - [ ] Add custom recording rules for common queries
 - [ ] Set up remote write for long-term metric storage
 - [ ] Add application-specific metrics (TeslaMate)
 - [ ] Configure Grafana alerting as backup to Alertmanager
 
 ### Known Issues
+
 - `amd.nerdsbythehour.com` excluded from probes (service broken)
 - `traefik.nerdsbythehour.com` excluded (internal dashboard, not publicly exposed)
 - `jimsmcp.nerdsbythehour.com` excluded (internal service)
@@ -632,6 +668,7 @@ Authentik exposes metrics at `:9300/metrics`:
 ## Recent Changes
 
 ### 2026-01-22: Service Failure Monitoring
+
 - Added HTTP probe modules (http_2xx, http_2xx_3xx) to blackbox-exporter
 - Configured blackbox-exporter with local DNS (192.168.68.1)
 - Created `scrape-configs.blackbox.yaml` for external service probes

--- a/apps/production/monitoring/node-exporter/README.md
+++ b/apps/production/monitoring/node-exporter/README.md
@@ -12,36 +12,42 @@ Node Exporter exposes hardware and kernel-level metrics from the host system to 
 ## What It Monitors
 
 ### CPU Metrics
+
 - CPU usage per core
 - CPU time by mode (user, system, idle, iowait)
 - Context switches
 - Interrupts
 
 ### Memory Metrics
+
 - Total, available, used memory
 - Swap usage
 - Page faults
 - Memory pressure
 
 ### Disk Metrics
+
 - Disk I/O operations
 - Read/write throughput
 - Disk space usage per filesystem
 - Inode usage
 
 ### Network Metrics
+
 - Network traffic (bytes in/out)
 - Packet counts
 - Network errors and drops
 - Connection states
 
 ### System Metrics
+
 - System load averages (1m, 5m, 15m)
 - Uptime
 - Number of processes
 - File descriptors
 
 ### Additional Collectors
+
 - Systemd unit states
 - Temperature sensors (if available)
 - Network statistics
@@ -81,7 +87,7 @@ annotations:
 
 ### Verify Scraping
 
-1. Go to Prometheus: https://prometheus.nerdsbythehour.com/targets
+1. Go to Prometheus: <https://prometheus.nerdsbythehour.com/targets>
 2. Look for `kubernetes-pods` job
 3. Find `node-exporter` targets - should show as "UP"
 
@@ -106,7 +112,7 @@ Import these dashboard IDs in Grafana (Dashboards → Import):
 
 ### Import Steps
 
-1. Navigate to Grafana: https://grafana.nerdsbythehour.com
+1. Navigate to Grafana: <https://grafana.nerdsbythehour.com>
 2. Click **Dashboards** → **Import**
 3. Enter dashboard ID (e.g., `1860`)
 4. Select **Prometheus** as data source
@@ -172,6 +178,7 @@ node_load15
 ### Enabled Collectors
 
 The following collectors are enabled:
+
 - `processes` - Process statistics
 - `systemd` - Systemd unit status
 - Default collectors (cpu, memory, disk, network, etc.)
@@ -207,15 +214,17 @@ kubectl logs -n monitoring <node-exporter-pod>
 ### Metrics Not Appearing in Prometheus
 
 1. Verify pod annotations:
+
    ```bash
    kubectl get pod -n monitoring -l app=node-exporter -o yaml | grep prometheus
    ```
 
 2. Check Prometheus targets:
-   - Go to https://prometheus.nerdsbythehour.com/targets
+   - Go to <https://prometheus.nerdsbythehour.com/targets>
    - Search for "node-exporter"
 
 3. Test metrics endpoint directly:
+
    ```bash
    kubectl port-forward -n monitoring <node-exporter-pod> 9100:9100
    curl localhost:9100/metrics
@@ -224,6 +233,7 @@ kubectl logs -n monitoring <node-exporter-pod>
 ### No Systemd Metrics
 
 If systemd metrics aren't appearing, ensure:
+
 - The pod has `hostPID: true`
 - Volume mount for `/host/sys` is correct
 - Running with proper privileges
@@ -231,12 +241,14 @@ If systemd metrics aren't appearing, ensure:
 ## Security
 
 Node Exporter runs with:
+
 - `runAsNonRoot: true`
 - `runAsUser: 65534` (nobody user)
 - Minimal capabilities (all dropped)
 - Read-only volume mounts
 
 It requires:
+
 - `hostNetwork: true` - To see host network stats
 - `hostPID: true` - To see all processes
 - `hostIPC: true` - For complete system view

--- a/apps/production/monitoring/node-exporter/grafana-dashboard-import.md
+++ b/apps/production/monitoring/node-exporter/grafana-dashboard-import.md
@@ -2,12 +2,12 @@
 
 ## Quick Import Instructions
 
-1. **Open Grafana**: https://grafana.nerdsbythehour.com
+1. **Open Grafana**: <https://grafana.nerdsbythehour.com>
 
 2. **Navigate to Import**:
    - Click the **+** icon (or menu) in the left sidebar
    - Select **Import dashboard**
-   - Or go directly to: https://grafana.nerdsbythehour.com/dashboard/import
+   - Or go directly to: <https://grafana.nerdsbythehour.com/dashboard/import>
 
 3. **Import Dashboard 1860 (Node Exporter Full)**:
    - Enter dashboard ID: `1860`
@@ -18,9 +18,11 @@
 ## Recommended Dashboards
 
 ### 1. Node Exporter Full (Dashboard ID: 1860) ⭐ RECOMMENDED
-**Best comprehensive dashboard for host metrics**
+
+#### Best comprehensive dashboard for host metrics
 
 Shows:
+
 - CPU Usage (per core and overall)
 - Memory Usage (RAM, Swap, Cache)
 - Disk I/O and Space
@@ -31,23 +33,28 @@ Shows:
 - Context Switches
 
 **Features:**
+
 - Multiple time ranges
 - Per-node view
 - Detailed breakdowns
 - Most popular Node Exporter dashboard (1M+ downloads)
 
 ### 2. Node Exporter Server Metrics (Dashboard ID: 11074)
-**Clean, modern alternative**
+
+#### Clean, modern alternative
 
 Shows:
+
 - CPU, Memory, Disk overview
 - Clean card-based layout
 - Less cluttered than 1860
 
 ### 3. Node Exporter for Prometheus (Dashboard ID: 13978)
-**Simple and focused**
+
+#### Simple and focused
 
 Shows:
+
 - Key metrics only
 - Easy to read at a glance
 - Good for NOC displays
@@ -57,6 +64,7 @@ Shows:
 If you prefer to import via JSON:
 
 1. Download dashboard JSON:
+
    ```bash
    curl -o node-exporter-full.json \
      https://grafana.com/api/dashboards/1860/revisions/latest/download
@@ -73,7 +81,7 @@ If you prefer to import via JSON:
 
 Before importing dashboards, verify Node Exporter metrics in Prometheus:
 
-1. Go to: https://prometheus.nerdsbythehour.com/graph
+1. Go to: <https://prometheus.nerdsbythehour.com/graph>
 
 2. Run these test queries:
 
@@ -111,12 +119,13 @@ After importing, you can customize:
 ### Dashboard Shows "No Data"
 
 1. **Check Node Exporter is running**:
+
    ```bash
    kubectl get pods -n monitoring -l app=node-exporter
    ```
 
 2. **Check Prometheus targets**:
-   - Go to: https://prometheus.nerdsbythehour.com/targets
+   - Go to: <https://prometheus.nerdsbythehour.com/targets>
    - Look for node-exporter targets
    - Should show as "UP"
 

--- a/apps/production/shared-resources/README.md
+++ b/apps/production/shared-resources/README.md
@@ -6,7 +6,7 @@ Static file server (nginx) that serves shared resources like icons, logos, and o
 
 ## URL
 
-**Production**: https://cdn.nerdsbythehour.com
+**Production**: <https://cdn.nerdsbythehour.com>
 
 ## Purpose
 
@@ -18,6 +18,7 @@ Static file server (nginx) that serves shared resources like icons, logos, and o
 ## Data Paths
 
 **Source Data** (NFS mount, backed up):
+
 ```
 /home/jim/docs/data/systems/shared-resources/
 ├── icons/              # General application icons
@@ -26,7 +27,7 @@ Static file server (nginx) that serves shared resources like icons, logos, and o
 └── README.md
 ```
 
-**Served via nginx at**: https://cdn.nerdsbythehour.com
+**Served via nginx at**: <https://cdn.nerdsbythehour.com>
 
 ## Architecture
 
@@ -43,6 +44,7 @@ Static file server (nginx) that serves shared resources like icons, logos, and o
 ### nginx Configuration
 
 Custom nginx config includes:
+
 - Autoindex enabled for directory browsing
 - Cache headers for static assets (30 days)
 - Security headers
@@ -55,6 +57,7 @@ See `configmap.yaml` for full nginx configuration.
 ### For Authentik Applications
 
 When configuring applications in Authentik Admin UI, use URLs like:
+
 ```
 https://cdn.nerdsbythehour.com/icons-logos/home-assistant-logo/icon.png
 ```
@@ -62,6 +65,7 @@ https://cdn.nerdsbythehour.com/icons-logos/home-assistant-logo/icon.png
 ### For Other Applications
 
 Reference assets directly by URL:
+
 ```html
 <img src="https://cdn.nerdsbythehour.com/icons/app-icon.png" />
 ```
@@ -69,11 +73,13 @@ Reference assets directly by URL:
 ## Adding New Assets
 
 1. Add files to the NFS mount:
+
    ```bash
    cp my-icon.png /home/jim/docs/data/systems/shared-resources/icons/
    ```
 
 2. Assets are immediately available at:
+
    ```
    https://cdn.nerdsbythehour.com/icons/my-icon.png
    ```
@@ -95,16 +101,19 @@ None required - public read-only static file server.
 ## Deployment
 
 Managed by Flux GitOps from:
+
 ```
 apps/production/shared-resources/
 ```
 
 Manual apply:
+
 ```bash
 kubectl apply -k apps/production/shared-resources/
 ```
 
 Force Flux reconciliation:
+
 ```bash
 flux reconcile kustomization apps
 ```
@@ -112,22 +121,26 @@ flux reconcile kustomization apps
 ## Troubleshooting
 
 ### Check pod status
+
 ```bash
 kubectl get pods -n shared-resources
 kubectl logs -n shared-resources -l app=shared-resources
 ```
 
 ### Verify ingress
+
 ```bash
 kubectl get ingress -n shared-resources
 ```
 
 ### Test locally
+
 ```bash
 curl https://cdn.nerdsbythehour.com/
 ```
 
 ### Check certificate
+
 ```bash
 kubectl get certificate -n shared-resources
 ```
@@ -148,6 +161,7 @@ kubectl get certificate -n shared-resources
 ## DNS Configuration
 
 Add DNS record in Cloudflare:
+
 ```
 Type: A
 Name: cdn

--- a/apps/production/teslamate/README.md
+++ b/apps/production/teslamate/README.md
@@ -5,10 +5,10 @@ TeslaMate is a self-hosted data logger for Tesla vehicles with real-time trackin
 ## Overview
 
 - **Namespace**: `teslamate`
-- **URL**: https://teslamate.nerdsbythehour.com
+- **URL**: <https://teslamate.nerdsbythehour.com>
 - **Database**: Shared PostgreSQL in `database` namespace
 - **MQTT**: Shared Mosquitto in `messaging` namespace
-- **Grafana**: https://grafana.nerdsbythehour.com (monitoring namespace)
+- **Grafana**: <https://grafana.nerdsbythehour.com> (monitoring namespace)
 
 ## Architecture
 
@@ -22,6 +22,7 @@ TeslaMate App (teslamate ns)
 ## Dependencies
 
 **Required Services** (must be running):
+
 1. PostgreSQL with teslamate database (`postgresql.database.svc.cluster.local:5432`)
 2. Mosquitto MQTT broker (`mosquitto.messaging.svc.cluster.local:1883`)
 3. Grafana for dashboards (`grafana.jimwilleke.com`)
@@ -35,12 +36,14 @@ sudo kubectl apply -k apps/production/teslamate/
 ## Configuration
 
 ### Database Connection
+
 - Host: `postgresql.database.svc.cluster.local`
 - Database: `teslamate`
 - User: `teslamate`
 - Password: Stored in `teslamate-secret`
 
 ### MQTT Connection
+
 - Host: `mosquitto.messaging.svc.cluster.local`
 - Port: `1883`
 - Topics: `teslamate/*`
@@ -48,6 +51,7 @@ sudo kubectl apply -k apps/production/teslamate/
 ### Security
 
 **Secrets** (`teslamate-secret.yaml`):
+
 - `encryption-key`: Encrypts sensitive Tesla API credentials
 - `database-password`: PostgreSQL password
 
@@ -64,6 +68,7 @@ kubectl edit secret teslamate-secret -n teslamate
 ### Authentik Protection
 
 To enable authentication, uncomment in `teslamate-ingress.yaml`:
+
 ```yaml
 traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
 ```
@@ -100,7 +105,7 @@ sudo kubectl exec -n database postgresql-0 -- psql -U teslamate -d teslamate -c 
 
 ### Add TeslaMate Data Source
 
-1. Access Grafana: https://grafana.nerdsbythehour.com
+1. Access Grafana: <https://grafana.nerdsbythehour.com>
 2. Configuration → Data Sources → Add data source → PostgreSQL
 3. Settings:
    - **Name**: TeslaMate
@@ -162,12 +167,14 @@ SELECT * FROM drives ORDER BY start_date DESC LIMIT 5;
 ### TeslaMate Won't Start
 
 **Error**: Permission denied creating extensions
+
 ```
 Solution: Grant superuser to teslamate user
 sudo kubectl exec -n database postgresql-0 -- psql -U postgres -d teslamate -c "ALTER USER teslamate WITH SUPERUSER;"
 ```
 
 **Error**: Can't connect to database
+
 ```
 Check PostgreSQL is running:
 sudo kubectl get pods -n database
@@ -208,7 +215,8 @@ sudo kubectl run -it --rm mqtt-test --image=eclipse-mosquitto:2 --restart=Never 
 ## Tesla API
 
 TeslaMate uses your Tesla account credentials to access vehicle data:
-1. Access https://teslamate.nerdsbythehour.com
+
+1. Access <https://teslamate.nerdsbythehour.com>
 2. Sign in with your Tesla credentials
 3. Grant access to your vehicle(s)
 4. Data logging begins automatically
@@ -251,6 +259,6 @@ sudo kubectl rollout restart deployment/teslamate -n teslamate
 
 ## Resources
 
-- TeslaMate GitHub: https://github.com/teslamate-org/teslamate
-- Documentation: https://docs.teslamate.org/
-- Community: https://github.com/teslamate-org/teslamate/discussions
+- TeslaMate GitHub: <https://github.com/teslamate-org/teslamate>
+- Documentation: <https://docs.teslamate.org/>
+- Community: <https://github.com/teslamate-org/teslamate/discussions>

--- a/docker-migration.md
+++ b/docker-migration.md
@@ -9,12 +9,11 @@ Except for:
 - traefik-docker (will be deleted)
 - dashy can be deleted we will use Authentik
 
-Migrated to be in k3s managed by https://github.com/jwilleke/mj-infra-flux (We are in cloned repo)
- 
- 
+Migrated to be in k3s managed by <https://github.com/jwilleke/mj-infra-flux> (We are in cloned repo)
+
 The Landing page should be the "home" page for everyone.
 
-The Members page (MembersPage.tsx) will be replaced with Authentik. (https://auth.nerdsbythehour.com/if/user/#/library)
+The Members page (MembersPage.tsx) will be replaced with Authentik. (<https://auth.nerdsbythehour.com/if/user/#/library>)
 
 The Guests Page (GuestPage.tsx) should contain
 
@@ -30,9 +29,10 @@ I would like if all k3s would be owned by apps:apps (uid 3003) (gid 3003)
 ### ✅ Phase 1 Complete: Stateless Applications
 
 **C. Landing Page** ✅ COMPLETE
+
 - Status: Deployed to k3s
 - Namespace: `landingpage`
-- URL: https://nerdsbythehour.com
+- URL: <https://nerdsbythehour.com>
 - Routes:
   - `/` - Public landing page
   - `/guest` - Guest page with links to openspeedtest and whoami
@@ -45,9 +45,10 @@ I would like if all k3s would be owned by apps:apps (uid 3003) (gid 3003)
 - Commit: 2ac59b8
 
 **B. whoami** ✅ COMPLETE
+
 - Status: Migrated from default namespace to GitOps
 - Namespace: `guest-services`
-- URL: https://deby.nerdsbythehour.com
+- URL: <https://deby.nerdsbythehour.com>
 - Changes:
   - Imported into GitOps from manual deployment
   - Moved from default to guest-services namespace
@@ -56,9 +57,10 @@ I would like if all k3s would be owned by apps:apps (uid 3003) (gid 3003)
 - Commit: 237dea6
 
 **A. openspeedtest** ✅ COMPLETE
+
 - Status: Deployed to k3s
 - Namespace: `guest-services`
-- URL: https://nerdsbythehour.com/speed
+- URL: <https://nerdsbythehour.com/speed>
 - Changes:
   - Built custom image from /opt/traefik/openspeedtest
   - Imported to k3s containerd
@@ -69,6 +71,7 @@ I would like if all k3s would be owned by apps:apps (uid 3003) (gid 3003)
 ### ✅ Phase 2 Complete: Shared Infrastructure & TeslaMate
 
 **PostgreSQL** (Shared Instance) ✅ COMPLETE
+
 - Status: Deployed to k3s
 - Namespace: `database`
 - Service: `postgresql.database.svc.cluster.local:5432`
@@ -77,6 +80,7 @@ I would like if all k3s would be owned by apps:apps (uid 3003) (gid 3003)
 - Commit: 6d1dd39
 
 **Mosquitto MQTT** (Shared Broker) ✅ COMPLETE
+
 - Status: Deployed to k3s
 - Namespace: `messaging`
 - Service: `mosquitto.messaging.svc.cluster.local:1883`
@@ -85,17 +89,19 @@ I would like if all k3s would be owned by apps:apps (uid 3003) (gid 3003)
 - Commit: 6d1dd39
 
 **Grafana** (Shared Dashboards) ✅ COMPLETE
+
 - Status: Deployed to k3s
 - Namespace: `monitoring`
-- URL: https://grafana.jimwilleke.com
+- URL: <https://grafana.jimwilleke.com>
 - Storage: `/mnt/local-k3s-data/grafana`
 - Ready for TeslaMate datasource
 - Commit: 3db228c
 
 **TeslaMate** ✅ COMPLETE
+
 - Status: Deployed to k3s
 - Namespace: `teslamate`
-- URL: https://teslamate.nerdsbythehour.com
+- URL: <https://teslamate.nerdsbythehour.com>
 - Connected to: Shared PostgreSQL + Shared MQTT
 - Data migration: Ready (instructions in README)
 - Commit: 3db228c
@@ -103,9 +109,10 @@ I would like if all k3s would be owned by apps:apps (uid 3003) (gid 3003)
 ### ✅ Phase 3 Complete: jimswiki
 
 **jimswiki** ✅ COMPLETE
+
 - Status: Deployed to k3s
 - Namespace: `jimswiki`
-- URL: https://nerdsbythehour.com/jimswiki/
+- URL: <https://nerdsbythehour.com/jimswiki/>
 - Data: Host mount at /home/jim/docs/data/systems/wikis/jimswiki (38,004 pages, 3.4GB)
 - Image: `aug12018/jimswiki:latest` (imported to k3s)
 - Context: Webapp deployed at `/jimswiki` (not ROOT)
@@ -120,6 +127,7 @@ I would like if all k3s would be owned by apps:apps (uid 3003) (gid 3003)
 ### 🗑️ To Be Removed from Docker
 
 After all migrations complete:
+
 - Stop: `cd /opt/traefik && docker-compose down`
 - Remove: authelia, dashy, traefik containers
 - Archive: /opt/traefik directory for reference
@@ -127,16 +135,19 @@ After all migrations complete:
 ### 📝 Current Status
 
 **Migration Status**: Phase 3 COMPLETE ✅ - ALL MIGRATIONS DONE!
+
 - ✅ Phase 1: Stateless apps (landingpage, openspeedtest, whoami)
 - ✅ Phase 2: Shared infrastructure (PostgreSQL, Mosquitto, Grafana) + TeslaMate
 - ✅ Phase 3: jimswiki (38,004 pages migrated)
 
 **Docker Services**: All stopped
+
 - Running on same host with same IP (192.168.68.71)
 - k3s Traefik ingress handling all traffic
 - No DNS changes needed - seamless cutover
 
 **Verification**:
+
 ```bash
 docker ps -a  # Shows all containers exited
 sudo kubectl get ingress -A  # Shows k3s ingresses active
@@ -158,7 +169,7 @@ sudo kubectl get pods -A  # Shows all k3s services running
 
 3. **jimswiki Migration** ✅ COMPLETE:
    - Deployed to k3s with all 38,004 pages
-   - Running at https://nerdsbythehour.com/jimswiki/
+   - Running at <https://nerdsbythehour.com/jimswiki/>
    - All data paths preserved
    - Details: `apps/production/jimswiki/README.md`
 

--- a/infrastructure/base/configs/image-scanning-webhook-receiver/README.md
+++ b/infrastructure/base/configs/image-scanning-webhook-receiver/README.md
@@ -1,1 +1,1 @@
-Per https://fluxcd.io/flux/guides/webhook-receivers/
+Per <https://fluxcd.io/flux/guides/webhook-receivers/>

--- a/security/SECURITY-INCIDENT.md
+++ b/security/SECURITY-INCIDENT.md
@@ -18,6 +18,7 @@ The following secrets were committed in plaintext in `apps/production/authentik/
 ### ✅ Step 1: Remove Secrets from Current Code (Completed)
 
 Commit `de98c43` removed plaintext secrets:
+
 - Updated HelmRelease to use `valuesFrom` with Secret reference
 - Secrets now stored only in Kubernetes cluster
 - Added SECRET-MANAGEMENT.md documentation
@@ -71,6 +72,7 @@ git push --force origin master
 ```
 
 **Note:** Only do this if:
+
 - You're the sole maintainer
 - Or you've coordinated with all team members
 - You understand the implications of rewriting history

--- a/security/SECURITY.md
+++ b/security/SECURITY.md
@@ -1,9 +1,11 @@
 # Security Vulnerabilities Report
+
 **nerdsbythehour.com** - ZeroThreat Scan (December 11, 2025)
 
 ---
 
 ## Summary
+
 - **Overall Risk Level**: Medium
 - **Total Vulnerabilities**: 46 (39 Medium, 3 Low, 3 Information)
 - **Compliance Status**: OWASP Top 10 (Fail), HIPAA (Fail), PCI DSS (Fail), ISO 27001-A (Fail), GDPR (Pass)
@@ -15,15 +17,19 @@
 ### =4 PRIORITY 1: MEDIUM SEVERITY (Implement Immediately)
 
 #### 1. Content Security Policy Not Implemented (24 instances)
+
 **Risk Factor**: Medium | **CVSS Score**: 3.1
 **Impact**: Allows XSS attacks, data injection, and clickjacking
 
 **Recommendation**:
+
 - Implement a robust Content Security Policy header on all responses
 - Start with a restrictive policy and gradually relax as needed:
+
   ```
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'
   ```
+
 - Remove inline scripts and styles; use external files with nonces
 - Test policy thoroughly before enforcing to avoid breaking functionality
 - Monitor CSP violations in real-time
@@ -31,14 +37,18 @@
 ---
 
 #### 2. ClickJacking / Improper Restriction of Rendered UI Layers (15 instances)
+
 **Risk Factor**: Medium | **CVSS Score**: 5.4
 **Impact**: Allows framing attacks to trick users into unwanted actions
 
 **Recommendation**:
+
 - Add X-Frame-Options header to prevent clickjacking:
+
   ```
   X-Frame-Options: SAMEORIGIN
   ```
+
 - Implement frame-busting JavaScript as additional protection
 - Consider Content Security Policy `frame-ancestors 'self'` directive
 - Apply to all pages, especially admin and sensitive areas
@@ -47,37 +57,47 @@
 ---
 
 #### 3. Insecure Access-Control-Allow-Origin Header (7 instances)
+
 **Risk Factor**: Medium | **CVSS Score**: 3.1
 **Impact**: Allows unauthorized cross-origin access to sensitive data
 
 **Recommendation**:
+
 - **CRITICAL**: Never use wildcard (`*`) in Access-Control-Allow-Origin for authenticated endpoints
 - Define explicit trusted domains:
+
   ```
   Access-Control-Allow-Origin: https://trusted-domain.com
   ```
+
 - Remove dynamic origin reflection if present
 - If credentials are allowed, explicitly specify origin:
+
   ```
   Access-Control-Allow-Origin: https://specific-domain.com
   Access-Control-Allow-Credentials: true
   ```
+
 - Only allow CORS on endpoints that absolutely require it
 - Review `/assets/` directory CORS configuration immediately
 
 ---
 
-### =á PRIORITY 2: LOW SEVERITY (Implement Soon)
+### =ï¿½ PRIORITY 2: LOW SEVERITY (Implement Soon)
 
 #### 4. Strict Transport Security Not Enforced (15 instances)
+
 **Risk Factor**: Low | **CVSS Score**: 6.5
 **Impact**: Vulnerability to man-in-the-middle attacks and eavesdropping
 
 **Recommendation**:
+
 - Enable HSTS with appropriate max-age:
+
   ```
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   ```
+
 - Use `max-age=31536000` (1 year) for production
 - Include `preload` directive to add domain to HSTS preload list
 - Test HSTS in staging before production deployment
@@ -86,14 +106,18 @@
 ---
 
 #### 5. X-Content-Type-Options Header Missing (24 instances)
+
 **Risk Factor**: Low | **CVSS Score**: 3.1
 **Impact**: Browser MIME-type sniffing can lead to XSS attacks
 
 **Recommendation**:
+
 - Add X-Content-Type-Options header to all responses:
+
   ```
   X-Content-Type-Options: nosniff
   ```
+
 - Ensure all resources have correct Content-Type headers
 - Apply globally via middleware/server configuration
 - Verify CSS files return `Content-Type: text/css`
@@ -104,10 +128,12 @@
 ### 9 PRIORITY 3: INFORMATION LEVEL (Address)
 
 #### 6. Email Address Disclosed (2 instances)
+
 **Risk Factor**: Information | **Location**: `/speed` and `/speed/assets/js/app-2.5.4.min.js`
 **Impact**: Exposed emails vulnerable to spam and phishing
 
 **Recommendation**:
+
 - Remove email addresses from source code and minified JS files
 - Check the `/speed` page and `app-2.5.4.min.js` for exposed email addresses
 - Move email contact info to server-side rendering or obfuscate in client code
@@ -118,21 +144,27 @@
 ---
 
 #### 7. TRACE/TRACK Method Detected (1 instance)
+
 **Risk Factor**: Information | **CVSS Score**: 5.3
 **Impact**: Exposes headers and session data for reconnaissance
 
 **Recommendation**:
+
 - Disable HTTP TRACE and TRACK methods on web server
 - For Apache, add to configuration:
+
   ```
   TraceEnable Off
   ```
+
 - For Nginx, explicitly allow only needed methods:
+
   ```
   if ($request_method !~ ^(GET|HEAD|POST|PUT|DELETE|OPTIONS)$) {
     return 405;
   }
   ```
+
 - Verify in staging: `curl -X TRACE https://nerdsbythehour.com/` should return 405
 
 ---
@@ -140,21 +172,25 @@
 ## Additional Findings
 
 ### Mail Configuration Status
+
 - **2 Failures** (SMTP Reverse DNS Mismatch, SMTP Transaction Time)
 - **6 Passes** (DKIM, DMARC, SPF, TLS, Anti-spoofing)
 
 **Recommendation**:
+
 - Investigate SMTP reverse DNS mismatch
 - Test mail server connectivity
 - Verify DMARC/SPF/DKIM configuration is correct
 
 ### SSL Certificate
+
 - **Status**: A (Excellent)
 - **Valid Until**: 2026-02-15
 - **Protocols**: TLS 1.2, TLS 1.3
 - **Action**: None needed; certificate is well-configured
 
 ### JavaScript Packages
+
 - React-Dom: 19.2.0 
 - React Router: 7.9.5 
 - **Status**: No known vulnerabilities detected
@@ -176,18 +212,21 @@
 ## Implementation Roadmap
 
 ### Week 1 (Critical)
+
 - [ ] Implement Content Security Policy
 - [ ] Add X-Frame-Options header
 - [ ] Fix CORS configuration
 - [ ] Remove/obfuscate email addresses
 
 ### Week 2 (High Priority)
+
 - [ ] Enable Strict-Transport-Security
 - [ ] Add X-Content-Type-Options header
 - [ ] Disable TRACE/TRACK methods
 - [ ] Fix SMTP configuration
 
 ### Ongoing
+
 - [ ] Set up regular security scanning
 - [ ] Update dependencies when vulnerabilities are found
 - [ ] Monitor HSTS preload status
@@ -196,6 +235,7 @@
 ---
 
 ## References
+
 - [OWASP Top 10 2021](https://owasp.org/Top10/)
 - [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
 - [HTTP Strict Transport Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)


### PR DESCRIPTION
## What

Makes the `markdown-lint` CI gate **green** — it was failing on **every** PR and push with **600 errors** across existing docs (a perpetually-red check trains everyone to ignore CI).

Fixed the markdown, **did not disable any rules** (per request):
- `markdownlint-cli2 --fix` cleared 594 (MD032/MD031/MD022 blanks-around-*, MD034 bare URLs, MD009 trailing spaces, MD005/MD007 list indent, MD029 ol-prefix, MD047 trailing newline, MD012 multiple blanks).
- 6 manual fixes (not auto-fixable): `AGENTS.md` duplicate H1 → H2; `traefik-ingress/README.md` non-descriptive `[here]` link text → descriptive; 3× emphasis-as-heading → `####` headings in `grafana-dashboard-import.md`.

## No line wrapping

`MD013` (line-length) is **not** among the violations, so **no lines were wrapped** — consistent with the no-wrap convention.

## Verify

`markdownlint-cli2 "**/*.md" "!node_modules" "!dist" "!CHANGELOG.md"` → **0 errors**.