### PR TITLE
fix(owntracks): raise recorder memory limit 256Mi → 512Mi (stop OOMKills)

### DIFF
--- a/apps/production/owntracks/recorder-deployment.yaml
+++ b/apps/production/owntracks/recorder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
               memory: "64Mi"
             limits:
               cpu: "500m"
-              memory: "256Mi"
+              memory: "512Mi"
           livenessProbe:
             tcpSocket:
               port: 8083


### PR DESCRIPTION
## Why

`owntracks-recorder` has been **OOMKilled** (exit 137) **6 times over 24 days** (last 2026-06-27 15:10) — it keeps hitting its `256Mi` memory limit and getting killed/restarted by the kernel OOM killer. The working set (24d+ of location data + the Lua hook + the view frontend on port 8083) has outgrown 256Mi.

```
Last State: Terminated   Reason: OOMKilled   Exit Code: 137
Restart Count: 6
limits.memory: 256Mi
```

## Change

Raise `limits.memory` **256Mi → 512Mi** for headroom (one line; `requests.memory` stays 64Mi). The pod self-recovers today, but the periodic OOM is a real recurring fault. Flux reconciles on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)