### PR TITLE
fix(deps): bump fast-uri to 3.1.4 in jimsmcp

### DIFF
--- a/apps/production/jimsmcp/package-lock.json
+++ b/apps/production/jimsmcp/package-lock.json
@@ -745,9 +745,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Bumps `fast-uri` 3.1.2 → 3.1.4 in `apps/production/jimsmcp/package-lock.json` — a lockfile-only fix, no `package.json` change needed since `ajv@8.18.0` (the only consumer, `node_modules/ajv` → `fast-uri: ^3.0.1`) already permits any 3.x.

Resolves:
- [Dependabot #90](https://github.com/jwilleke/mj-infra-flux/security/dependabot/90) — high — host confusion via literal backslash authority delimiter (fixed in 3.1.4)
- [Dependabot #89](https://github.com/jwilleke/mj-infra-flux/security/dependabot/89) — high — host confusion via failed IDN canonicalization (fixed in 3.1.3)

## Not in this PR

[Dependabot #85](https://github.com/jwilleke/mj-infra-flux/security/dependabot/85) (`@hono/node-server`, medium) needs a major bump (1.19.13 → 2.0.5) that `@modelcontextprotocol/sdk` doesn't permit — even at latest (1.29.0) it still declares `@hono/node-server: ^1.19.9`. Forcing 2.x would need an `overrides` entry against the SDK's own stated range. Also worth noting: the underlying vulnerability is Windows-specific path traversal in `serve-static`; this runs in a Linux container, so actual exploitability here is low. Holding off rather than forcing an unverified major bump — separate issue if worth tracking.

`hono` itself (medium, #86/#87/#88) is already covered by open [#142](https://github.com/jwilleke/mj-infra-flux/pull/142).

## Verification

`npm ls fast-uri` confirms `3.1.4` resolved via `@modelcontextprotocol/sdk@1.26.0 > ajv@8.18.0 > fast-uri@3.1.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)