### PR TITLE
fix(#144): force @hono/node-server to 2.0.12 via npm override

### DIFF
--- a/apps/production/jimsmcp/package-lock.json
+++ b/apps/production/jimsmcp/package-lock.json
@@ -22,12 +22,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/apps/production/jimsmcp/package.json
+++ b/apps/production/jimsmcp/package.json
@@ -30,5 +30,8 @@
   "devDependencies": {
     "@types/node": "^22.10.5",
     "typescript": "^5.7.2"
+  },
+  "overrides": {
+    "@hono/node-server": "^2.0.5"
   }
 }


### PR DESCRIPTION
Closes #144.

## The problem

Dependabot alert #85 (medium): `@hono/node-server < 2.0.5` has a path-traversal vulnerability in `serve-static` on Windows via encoded backslash. Currently resolved to `1.19.13` as a transitive dependency of `@modelcontextprotocol/sdk` in `apps/production/jimsmcp`.

A normal bump isn't possible: `@modelcontextprotocol/sdk` still declares `@hono/node-server: ^1.19.9` even at its own latest release (1.29.0, ahead of the 1.26.0 installed here) — a 1.x-only range.

## The fix

Added an npm `overrides` entry in `apps/production/jimsmcp/package.json` forcing `@hono/node-server` to `^2.0.5`, resolving to `2.0.12`.

## Why this is safe despite overriding the SDK's own declared range

Traced where `@hono/node-server` is actually reachable from: only the SDK's bundled example code, `examples/server/honoWebStandardStreamableHttp.js` — `jimsmcp` never imports it. Its own `src/http-server.ts` uses plain Node `http.createServer` plus the SDK's `StreamableHTTPServerTransport`; no Hono anywhere in the real runtime path. The vulnerable code was already unreachable in this deployment regardless of version — the override just clears the alert without touching anything jimsmcp actually executes.

## Verification

- `npm install` resolves `@hono/node-server@2.0.12` (marked `overridden`, satisfies the `>=2.0.5` fix range)
- `npm audit` — 0 vulnerabilities
- `npm run build` (`tsc`) — clean
- Runtime smoke test: started `dist/http-server.js` on a scratch port, `GET /mcp` → `406` (expected — no session headers, matches pre-change transport behavior) and `OPTIONS /mcp` → `200` (CORS preflight), clean shutdown on SIGTERM

🤖 Generated with [Claude Code](https://claude.com/claude-code)